### PR TITLE
25: Refactor the Fatal Error. 

### DIFF
--- a/src/Kit/Container/AvlTree_.cpp
+++ b/src/Kit/Container/AvlTree_.cpp
@@ -9,7 +9,7 @@
 /** @file */
 
 #include "AvlTree_.h"
-
+#include <limits.h>
 
 // Debugging
 // #include        <stdlib.h>
@@ -39,7 +39,12 @@ MapItem* AvlTree_::find( const Key& key ) const
     MapItem* nodePtr = m_root.getLeft();
     while ( nodePtr != nullptr )
     {
-        int8_t comparison = nodePtr->getKey().compareKey( key );
+        int comparison = nodePtr->getKey().compareKey( key );
+        if ( comparison == INT_MIN )
+        {
+            // Key is not compatible with the node's key type
+            return nullptr;
+        }
         if ( comparison > 0 )
         {
             nodePtr = nodePtr->getLeft();
@@ -79,9 +84,13 @@ bool AvlTree_::insert( MapItem& newNode )
     do
     {
         //      tpd_assert( depth < _maxTreeDepth );
-        int result           = curPtr->getKey().compareKey( newNode.getKey() );
-        comparison           = result < 0 ? -1 : result > 0 ? 1
-                                                            : 0;
+        int result = curPtr->getKey().compareKey( newNode.getKey() );
+        if ( result == INT_MIN )
+        {
+            // Key is not compatible with the node's key type
+            return false;
+        }
+        comparison = result < 0 ? -1 : result > 0 ? 1 : 0;
         comparisons[depth++] = comparison;
 
         if ( comparison > 0 )

--- a/src/Kit/Container/Item.cpp
+++ b/src/Kit/Container/Item.cpp
@@ -10,6 +10,7 @@
 
 #include "Item.h"
 #include "Kit/System/FatalError.h"
+#include "Kit/System/Shutdown.h"
 
 
 //------------------------------------------------------------------------------
@@ -20,7 +21,11 @@ bool Item::insert_( void* newContainerPtr ) noexcept
 {
     if ( m_inListPtr_ )
     {
-        Kit::System::FatalError::logf( "Container Error: Double Insert. item=%p, prev container=%p, new container=%p", this, m_inListPtr_, newContainerPtr );
+        Kit::System::FatalError::logf( Kit::System::Shutdown::eCONTAINER,
+                                       "Container Error: Double Insert. item=%p, prev container=%p, new container=%p",
+                                       this,
+                                       m_inListPtr_,
+                                       newContainerPtr );
         return false;
     }
     else
@@ -34,12 +39,15 @@ bool Item::validateNextOkay_( const void* containerPtr ) const noexcept
 {
     if ( m_inListPtr_ != containerPtr )
     {
-        Kit::System::FatalError::logf( "Container Error: Invalid next() call. item=%p, container=%p", this, containerPtr );
+        Kit::System::FatalError::logf( Kit::System::Shutdown::eCONTAINER,
+                                       "Container Error: Invalid next() call. item=%p, container=%p",
+                                       this,
+                                       containerPtr );
         return false;
     }
     return true;
 }
 
-} // end namespaces
+}  // end namespaces
 }
 //------------------------------------------------------------------------------

--- a/src/Kit/Container/Key.cpp
+++ b/src/Kit/Container/Key.cpp
@@ -42,9 +42,6 @@ const void* KeyStringBuffer::getRawKey( unsigned* returnRawKeyLenPtr ) const noe
 
 int KeyStringBuffer::compare( const char* myString, unsigned myLen, const char* otherString, unsigned otherLen ) noexcept
 {
-    KIT_SYSTEM_ASSERT( myString != nullptr );
-    KIT_SYSTEM_ASSERT( otherString != nullptr );
-    
     if ( otherString )
     {
         if ( myString )
@@ -61,7 +58,8 @@ int KeyStringBuffer::compare( const char* myString, unsigned myLen, const char* 
         }
     }
 
-    return -1;
+    // Not a valid key
+    return INT_MIN; 
 }
 
 }   // end namespaces

--- a/src/Kit/Container/Key.h
+++ b/src/Kit/Container/Key.h
@@ -11,10 +11,9 @@
 /** @file */
 
 // #include "kit_map.h"
-#include "Kit/System/Assert.h"
 #include <stdint.h>
 #include <string.h>
-
+#include <limits.h>
 
 ///
 namespace Kit {
@@ -33,6 +32,10 @@ public:
         The actual type of the 'key' is up to the client sub-class
         that implements this interface.  It is the responsibility of
         the sub-class to correctly define/interpret the data type of the key.
+
+        CAUTION: If the key being compared is NOT a compatible type or is not
+                 a valid key, then INT_MIN is returned. The caller of the method
+                 is responsible for checking for INT_MIN
 
      */
     virtual int compareKey( const Key& key ) const noexcept = 0;
@@ -85,7 +88,10 @@ public:
     {
         unsigned  len = 0;
         DATATYPE* ptr = static_cast<DATATYPE*>(const_cast<void*>(key.getRawKey( &len )));
-        KIT_SYSTEM_ASSERT( len == sizeof( DATATYPE ) );
+        if ( len != sizeof( DATATYPE ) )
+        {
+            return INT_MIN;  // Not a valid key
+        }
 
         if ( m_keyData < *ptr )
         {

--- a/src/Kit/Container/Map.h
+++ b/src/Kit/Container/Map.h
@@ -112,32 +112,30 @@ public:
     }
 
 
-    /// Returns the first item in the tree. Returns 0 if tree is empty
+    /// Returns the first item in the tree. The item remains in the tree. Returns 0 if tree is empty
     ITEM* first() const noexcept
     {
         return (ITEM*)m_tree.first();
     }
 
-
-    /// Returns the last item in the tree. Returns 0 if tree is empty
+    /// Returns the last item in the tree. The item remains in the tree. Returns 0 if tree is empty
     ITEM* last() const noexcept
     {
         return (ITEM*)m_tree.last();
     }
 
-
-    /// Returns the next item in the tree.  Returns 0 if at the end-of-tree
+    /// Returns the next item in the tree.  The item remains in the tree. Returns 0 if at the end-of-tree
     ITEM* next( ITEM& current ) const noexcept
     {
         return (ITEM*)m_tree.next( current );
     }
 
-
-    /// Returns the previous item in the tree.  Returns 0 if at the start-of-tree
+    /// Returns the previous item in the tree. The item remains in the tree. Returns 0 if at the start-of-tree
     ITEM* previous( ITEM& current ) const noexcept
     {
         return (ITEM*)m_tree.previous( current );
     }
+
 
     /** Removes the first item in the list.  Returns 0 if the list
         is empty.
@@ -151,7 +149,6 @@ public:
         }
         return nullptr;
     }
-
 
     /** Removes the last item in the list.  Returns 0 if the list
         is empty.

--- a/src/Kit/Container/_0test/map.cpp
+++ b/src/Kit/Container/_0test/map.cpp
@@ -158,8 +158,7 @@ TEST_CASE( "Map" )
 
 
         // Sneak in test for bogus keys
-        ptr2 = staticmap_.find( cherry );
-        REQUIRE( ShutdownUnitTesting::getAndClearCounter() >= 1u ); // Note: Since the behavior is undefined when FatalError::logf() returns -->I will hit more than one fatal error, how many more is somewhat 'random'
+        REQUIRE( staticmap_.find( cherry ) == nullptr );
     }
 
     SECTION( "Basic" )

--- a/src/Kit/Memory/_testsupport/NewUnitTesting.cpp
+++ b/src/Kit/Memory/_testsupport/NewUnitTesting.cpp
@@ -43,7 +43,7 @@ protected:
         }
         else if ( delta != newDeleteDelta_ )
         {
-            exitCode = OPTION_KIT_SYSTEM_SHUTDOWN_FAILURE_ERROR_CODE;
+            exitCode = Kit::System::Shutdown::eMEMORY;
             msg      = "ERROR: new/delete call delta does NOT match expected value.";
         }
 

--- a/src/Kit/System/FatalError.h
+++ b/src/Kit/System/FatalError.h
@@ -12,14 +12,9 @@
 
 
 #include "kit_config.h"
+#include "Kit/System/Shutdown.h"
+#include "Kit/System/printfchecker.h"
 #include <stdlib.h>
-
-/** Specifies the default value used for the application exit code when
-    terminating due to a fatal error.
- */
-#ifndef OPTION_KIT_SYSTEM_FATAL_ERROR_EXIT_CODE
-#define OPTION_KIT_SYSTEM_FATAL_ERROR_EXIT_CODE 2
-#endif
 
 
 ///
@@ -30,6 +25,11 @@ namespace System {
 /** This class defines methods for handling fatal errors encountered by
     an application.  The implementation of the methods is platform
     dependent.
+
+    All of the log() methods take an 'exitCode' argument.  The exitCode is
+    passed to the Shutdown::failure() method.  See the Shutdown.h header file
+    for list of KIT exit codes.  Note: The application can define it own exit
+    codes.
  */
 class FatalError
 {
@@ -42,20 +42,23 @@ public:
         type of "storage media", additional info, stopped behavior, etc.
         is defined by the selected/linked implementation.
 
-        NOTE: Applications, in general should NOT call this method - the
-        application should be DESIGNED to handle and recover from errors that it
-        encounters/detects.
+        NOTE: Components in general should NOT call this method. Instead the
+              component should be DESIGNED to handle and recover from errors
+              that it encounters/detects.  Components that can generate fatal
+              errors are limited in their reusability because one application's
+              fatal error is another application's recoverable error.
      */
-    static void log( const char* message );
+    static void log( int exitCode, const char* message );
 
     /** Same as above, but "value" is also logged.  This method allows additional
         information to be logged without resulting to a string formating call
         (which may not work since something really bad just happen).
      */
-    static void log( const char* message, size_t value );
+    static void log( int exitCode, const char* message, size_t value );
 
     /// Printf style formatted message
-    static void logf( const char* format, ... );
+    KIT_SYSTEM_PRINTF_CHECKER( 2, 3 )
+    static void logf( int exitCode, const char* format, ... );
 
 
 public:
@@ -67,10 +70,10 @@ public:
         write to media to be able to log fatal errors WITHOUT creating a
         recursive death loop.
      */
-    static void logRaw( const char* message );
+    static void logRaw( int exitCode, const char* message );
 
     /// Same as log(..) method, except NO 'extra info' and restricted media
-    static void logRaw( const char* message, size_t value );
+    static void logRaw( int exitCode, const char* message, size_t value );
 };
 
 

--- a/src/Kit/System/Posix/_fatalerror/FatalError.cpp
+++ b/src/Kit/System/Posix/_fatalerror/FatalError.cpp
@@ -6,14 +6,13 @@
  *
  * Redistributions of the source code must retain the above copyright notice.
  *----------------------------------------------------------------------------*/
-/** @file 
+/** @file
 
     Implementation of the System::FatalError interface using the standard
     C library.
 
     Notes:
         o The log messages are sent to stderr
-        o The application is exited with an errorcode of OPTION_KIT_SYSTEM_FATAL_ERROR_EXIT_CODE
         o 'Extra Info' is limited to a '@@ Fatal Error:' prefix
         o The implementation is NOT thread safe.
 */
@@ -24,7 +23,7 @@
 #include <stdio.h>
 
 
-#define EXTRA_INFO "@@ Fatal Error: "
+#define EXTRA_INFO "@@ Fatal Error"
 
 //------------------------------------------------------------------------------
 namespace Kit {
@@ -32,44 +31,43 @@ namespace System {
 
 
 //////////////////////////////
-void FatalError::log( const char* message )
+void FatalError::log( int exitCode, const char* message )
 {
-    fprintf( stderr, "\n%s%s\n", EXTRA_INFO, message );
-    Shutdown::failure( OPTION_KIT_SYSTEM_FATAL_ERROR_EXIT_CODE );
+    fprintf( stderr, "\n%s [%d]: %s\n", EXTRA_INFO, exitCode, message );
+    Shutdown::failure( exitCode );
 }
 
-void FatalError::log( const char* message, size_t value )
+void FatalError::log( int exitCode, const char* message, size_t value )
 {
-    fprintf( stderr, "\n%s%s [%p]\n", EXTRA_INFO, message, (void*) value );
-    Shutdown::failure( OPTION_KIT_SYSTEM_FATAL_ERROR_EXIT_CODE );
+    fprintf( stderr, "\n%s [%d]: %s [%p]\n", EXTRA_INFO, exitCode, message, (void*)value );
+    Shutdown::failure( exitCode );
 }
 
 
-void FatalError::logf( const char* format, ... )
+void FatalError::logf( int exitCode, const char* format, ... )
 {
     va_list ap;
     va_start( ap, format );
 
-    fprintf( stderr, "\n%s", EXTRA_INFO );
+    fprintf( stderr, "\n%s [%d]: ", EXTRA_INFO, exitCode );
     vfprintf( stderr, format, ap );
     fprintf( stderr, "\n" );
-    Shutdown::failure( OPTION_KIT_SYSTEM_FATAL_ERROR_EXIT_CODE );
+    Shutdown::failure( exitCode );
 }
 
 
 //////////////////////////////
-void FatalError::logRaw( const char* message )
+void FatalError::logRaw( int exitCode, const char* message )
 {
-    log( message );
+    log( exitCode, message );
 }
 
-void FatalError::logRaw( const char* message, size_t value )
+void FatalError::logRaw( int exitCode, const char* message, size_t value )
 {
-    log( message, value );
+    log( exitCode, message, value );
 }
 
 
-
-} // end namespaces
-} 
+}  // end namespaces
+}
 //------------------------------------------------------------------------------

--- a/src/Kit/System/Posix/mappings_.h
+++ b/src/Kit/System/Posix/mappings_.h
@@ -39,7 +39,7 @@
 
 
 /// Mapping
-#define KIT_SYSTEM_ASSERT_MAP(e)                do { if ( !(e) ) Kit::System::FatalError::logf( "ASSERT Failed at: file=%s, line=%d, func=%s\n", __FILE__, __LINE__, KIT_SYSTEM_ASSERT_PRETTY_FUNCNAME ); } while(0)
+#define KIT_SYSTEM_ASSERT_MAP(e)                do { if ( !(e) ) Kit::System::FatalError::logf( Kit::System::Shutdown::eASSERT, "ASSERT Failed at: file=%s, line=%d, func=%s\n", __FILE__, __LINE__, KIT_SYSTEM_ASSERT_PRETTY_FUNCNAME ); } while(0)
 
 
 /// Mapping

--- a/src/Kit/System/Shutdown.h
+++ b/src/Kit/System/Shutdown.h
@@ -15,23 +15,20 @@
 #include "Kit/Container/ListItem.h"
 
 
-/** Specifies the default value used for the application exit code when
-    terminating 'successfully'
+/** Starting value for KIT Library's exit codes.  It is strongly recommended that
+    applications do NOT override this value.
  */
-#ifndef OPTION_KIT_SYSTEM_SHUTDOWN_SUCCESS_ERROR_CODE
-#define OPTION_KIT_SYSTEM_SHUTDOWN_SUCCESS_ERROR_CODE 0
+#ifndef OPTION_KIT_SYSTEM_SHUTDOWN_BEGIN_EXIT_CODES
+#define OPTION_KIT_SYSTEM_SHUTDOWN_BEGIN_EXIT_CODES 0
 #endif
 
-
-/** Specifies the default value used for the application exit code when
-    terminating 'on a failure'
- */
-#ifndef OPTION_KIT_SYSTEM_SHUTDOWN_FAILURE_ERROR_CODE
-#define OPTION_KIT_SYSTEM_SHUTDOWN_FAILURE_ERROR_CODE 1
-#endif
+/** Total number of reserved exit codes for the KIT Library.  The application
+    can define its own exit codes starting at:
+    OPTION_KIT_SYSTEM_SHUTDOWN_BEGIN_EXIT_CODES + KIT_SYSTEM_SHUTDOWN_NUM_RESERVED_EXIT_CODES
+*/
+constexpr int KIT_SYSTEM_SHUTDOWN_NUM_RESERVED_EXIT_CODES = 100;
 
 
-///
 namespace Kit {
 ///
 namespace System {
@@ -52,6 +49,24 @@ namespace System {
  */
 class Shutdown
 {
+public:
+    /** Reserved exit codes for the KIT Library */
+    enum : int
+    {
+        eSUCCESS = OPTION_KIT_SYSTEM_SHUTDOWN_BEGIN_EXIT_CODES,  //!< Application terminated successfully
+        eFAILURE,                                                //!< Application terminated due to a failure.  This is a generic failure
+        eFATAL_ERROR,                                            //!< Application detected a fatal error and self terminated.  This is a generic failure
+        eASSERT,                                                 //!< Application terminated due to an assertion failure
+        eOSAL,                                                   //!< Application terminated due to an OSAL failure (e.g. error detected by a module in the Kit::System namespace)
+        eDATA_MODEL,                                             //!< Application terminated due to a Data Model failure
+        eCONTAINER,                                              //!< Application terminated due to a Container failure (e.g. crossed linked intrusive containers)
+        eSTREAMIO,                                               //!< Application terminated due to a stream I/O failure.  This includes errors in File IO, Sockets, Serial ports, etc.
+        eMEMORY,                                                 //!< Application terminated due to a memory failure (e.g. failed memory allocation)
+        eDRIVER,                                                 //!< Application terminated due to a driver failure.  This is a generic failure
+        eFSM_EVENT_OVERFLOW,                                     //!< Application terminated due to a finite state machine event overflow condition (i.e. a FSM event was-dropped/not-processed)
+        eWATCHDOG                                                //!< Application terminated due to a watchdog timeout (e.g. watchdog configuration errors, intentional WDOG trips)
+    };
+
 public:
     /** This call defines the callback interface that is used when the
         application is shutdown
@@ -91,14 +106,14 @@ public:
         exit code.  The caller can optional specify an exit code. What 'forced'
         means is dependent on the actual platform.  All registered callback
         methods will be called before exiting the application. The returned
-        value - assuming the method actually returns - will be the exit code 
+        value - assuming the method actually returns - will be the exit code
         returned by the last shutdown handler.
 
         Note: The recommended approach for exiting the application due to an
               error is to use the Cpl::System::FatalError interface so that
               the 'why' of the failure has the potential for being captured.
      */
-    static int failure( int exitCode = OPTION_KIT_SYSTEM_SHUTDOWN_FAILURE_ERROR_CODE ) noexcept;
+    static int failure( int exitCode = eFAILURE ) noexcept;
 
 
 public:

--- a/src/Kit/System/Win32/_fatalerror/FatalError.cpp
+++ b/src/Kit/System/Win32/_fatalerror/FatalError.cpp
@@ -6,14 +6,13 @@
  *
  * Redistributions of the source code must retain the above copyright notice.
  *----------------------------------------------------------------------------*/
-/** @file 
+/** @file
 
     Implementation of the System::FatalError interface using the standard
     C library.
 
     Notes:
         o The log messages are sent to stderr
-        o The application is exited with an errorcode of OPTION_KIT_SYSTEM_FATAL_ERROR_EXIT_CODE
         o 'Extra Info' is limited to a '@@ Fatal Error:' prefix
         o The implementation is NOT thread safe.
 */
@@ -24,7 +23,7 @@
 #include <stdio.h>
 
 
-#define EXTRA_INFO "@@ Fatal Error: "
+#define EXTRA_INFO "@@ Fatal Error"
 
 //------------------------------------------------------------------------------
 namespace Kit {
@@ -32,44 +31,43 @@ namespace System {
 
 
 //////////////////////////////
-void FatalError::log( const char* message )
+void FatalError::log( int exitCode, const char* message )
 {
-    fprintf( stderr, "\n%s%s\n", EXTRA_INFO, message );
-    Shutdown::failure( OPTION_KIT_SYSTEM_FATAL_ERROR_EXIT_CODE );
+    fprintf( stderr, "\n%s [%d]: %s\n", EXTRA_INFO, exitCode, message );
+    Shutdown::failure( exitCode );
 }
 
-void FatalError::log( const char* message, size_t value )
+void FatalError::log( int exitCode, const char* message, size_t value )
 {
-    fprintf( stderr, "\n%s%s [%p]\n", EXTRA_INFO, message, (void*) value );
-    Shutdown::failure( OPTION_KIT_SYSTEM_FATAL_ERROR_EXIT_CODE );
+    fprintf( stderr, "\n%s [%d]: %s [%p]\n", EXTRA_INFO, exitCode, message, (void*)value );
+    Shutdown::failure( exitCode );
 }
 
 
-void FatalError::logf( const char* format, ... )
+void FatalError::logf( int exitCode, const char* format, ... )
 {
     va_list ap;
     va_start( ap, format );
 
-    fprintf( stderr, "\n%s", EXTRA_INFO );
+    fprintf( stderr, "\n%s [%d]: ", EXTRA_INFO, exitCode );
     vfprintf( stderr, format, ap );
     fprintf( stderr, "\n" );
-    Shutdown::failure( OPTION_KIT_SYSTEM_FATAL_ERROR_EXIT_CODE );
+    Shutdown::failure( exitCode );
 }
 
 
 //////////////////////////////
-void FatalError::logRaw( const char* message )
+void FatalError::logRaw( int exitCode, const char* message )
 {
-    log( message );
+    log( exitCode, message );
 }
 
-void FatalError::logRaw( const char* message, size_t value )
+void FatalError::logRaw( int exitCode, const char* message, size_t value )
 {
-    log( message, value );
+    log( exitCode, message, value );
 }
 
 
-
-} // end namespaces
-} 
+}  // end namespaces
+}
 //------------------------------------------------------------------------------

--- a/src/Kit/System/Win32/mappings_.h
+++ b/src/Kit/System/Win32/mappings_.h
@@ -45,7 +45,7 @@
     do                                                                                                                                               \
     {                                                                                                                                                \
         if ( !( e ) )                                                                                                                                \
-            Kit::System::FatalError::logf( "ASSERT Failed at: file=%s, line=%d, func=%s\n", __FILE__, __LINE__, KIT_SYSTEM_ASSERT_PRETTY_FUNCNAME ); \
+            Kit::System::FatalError::logf( Kit::System::Shutdown::eASSERT, "ASSERT Failed at: file=%s, line=%d, func=%s\n", __FILE__, __LINE__, KIT_SYSTEM_ASSERT_PRETTY_FUNCNAME ); \
     }                                                                                                                                                \
     while ( 0 )
 

--- a/src/Kit/System/_testsupport/ShutdownUnitTesting.cpp
+++ b/src/Kit/System/_testsupport/ShutdownUnitTesting.cpp
@@ -9,8 +9,9 @@
 /** @file */
 
 #include "ShutdownUnitTesting.h"
+#include "Kit/System/Mutex.h"
 #include "Kit/System/Shutdown.h"
-
+#include "Kit/System/Private.h"
 
 
 ///
@@ -26,51 +27,41 @@ namespace System {
 ////////////////////////////////////////////////////////////////////////////////
 void ShutdownUnitTesting::clearAndUseCounter() noexcept
 {
-    // TODO: FIX ME
-    //Locks_::system().lock();
+    Mutex::ScopeLock criticalSection( PrivateLocks::system() );
     counter_  = 0;
     counting_ = true;
     testing_  = true;
-    //Locks_::system().unlock();
 }
 
 size_t ShutdownUnitTesting::getAndClearCounter() noexcept
 {
-    // TODO: FIX ME
-    //Locks_::system().lock();
+    Mutex::ScopeLock criticalSection( PrivateLocks::system() );
     size_t temp = counter_;
     counter_    = 0;
-    //Locks_::system().unlock();
-
     return temp;
 }
 
 
 void ShutdownUnitTesting::setExitCode( int newExitCode ) noexcept
 {
-    // TODO: FIX ME
-    //Locks_::system().lock();
+    Mutex::ScopeLock criticalSection( PrivateLocks::system() );
     exitCode_ = newExitCode;
     counting_ = false;
     testing_  = true;
-    //Locks_::system().unlock();
 }
 
 
 void ShutdownUnitTesting::restore() noexcept
 {
-    // TODO: FIX ME
-    //Locks_::system().lock();
+    Mutex::ScopeLock criticalSection( PrivateLocks::system() );
     testing_ = false;
-    //Locks_::system().unlock();
 }
 
 
 ////////////////////////////////////////////////////////////////////////////////
 static int preprocess_shutdown_( int exitCode, bool& trueExit ) noexcept
 {
-    // TODO: FIX ME
-    //Locks_::system().lock();
+    Mutex::ScopeLock criticalSection( PrivateLocks::system() );
 
     if ( !testing_ )
     {
@@ -90,14 +81,13 @@ static int preprocess_shutdown_( int exitCode, bool& trueExit ) noexcept
         }
     }
 
-    //Locks_::system().unlock();
     return exitCode;
 }
 
 int Shutdown::success() noexcept
 {
     bool trueExit = true;
-    int  exitCode = preprocess_shutdown_( OPTION_KIT_SYSTEM_SHUTDOWN_SUCCESS_ERROR_CODE, trueExit );
+    int  exitCode = preprocess_shutdown_( eSUCCESS, trueExit );
     if ( trueExit )
     {
         exitCode = notifyShutdownHandlers( exitCode );

--- a/src/Kit/System/_testsupport/ShutdownUnitTesting.h
+++ b/src/Kit/System/_testsupport/ShutdownUnitTesting.h
@@ -20,8 +20,8 @@
     Note: The fatal error count is reset everytime getAndClearCounter()
           is called.
  */
-#ifndef OPTION_KIT_SYSTEM_SHUTDOWN_TS_MAX_FATAL_ERRORS
-#define OPTION_KIT_SYSTEM_SHUTDOWN_TS_MAX_FATAL_ERRORS 10
+#ifndef OPTION_KIT_SYSTEM_SHUTDOWN_UNI_TESTING_MAX_FATAL_ERRORS
+#define OPTION_KIT_SYSTEM_SHUTDOWN_UNI_TESTING_MAX_FATAL_ERRORS 10
 #endif
 
 

--- a/src/Kit/System/printfchecker.h
+++ b/src/Kit/System/printfchecker.h
@@ -1,0 +1,55 @@
+#ifndef KIT_SYSTEM_PRINTF_CHECKER_H_
+#define KIT_SYSTEM_PRINTF_CHECKER_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file
+
+    This file contains macro that enables the GCC (and Clang) compiler to
+    validate printf flags with their corresponding arguments for home grown
+    functions that have printf semantics (e.g. Tracing and Logging).
+ */
+
+ /** The KIT_SYSTEM_PRINTF_CHECKER() macro is used to enable printf-style
+     argument checking - by the compiler - for custom logging functions. This
+     macro should be placed above the function declaration to specify the
+     positions of the format string and its corresponding arguments.
+     \code
+
+    'formatNum' - The 1-based position of the format string parameter. In the 
+                  function below 'formatNum' is parameter 2:
+
+                    void log(int level, const char* format, ...);
+                
+                  NOTE: For class methods, count the implicit 'this' pointer as parameter 1
+
+    'vargsNum' -  The 1-based position of the first variadic argument. This is 
+                  typically formatNum + 1. In the function below 'vargsNum' is 
+                  parameter 3:
+
+                    void log(int level, const char* format, ...), 
+    
+    Usage example:
+        KIT_SYSTEM_PRINTF_CHECKER(2, 3);  
+        void log(int level, const char* format, ...) 
+      
+        KIT_SYSTEM_PRINTF_CHECKER(3, 4); // The implicit 'this' argument is param 1
+        void MyClass::log(int level, const char* format, ...) 
+
+    \endcode
+ */
+#if defined( __GNUC__ )
+#define KIT_SYSTEM_PRINTF_CHECKER( formatNum, vargsNum ) __attribute__( ( format( printf, formatNum, vargsNum ) ) )
+#elif defined( __clang__ )
+#define KIT_SYSTEM_PRINTF_CHECKER( formatNum, vargsNum ) __attribute__( ( __format__( __printf__, formatNum, vargsNum ) ) )
+#else
+#define KIT_SYSTEM_PRINTF_CHECKER( formatNum, vargsNum )
+#endif
+
+
+#endif  // end header latch

--- a/src/Kit/Text/IString.h
+++ b/src/Kit/Text/IString.h
@@ -11,6 +11,7 @@
 /** @file */
 
 #include "Kit/Container/Key.h"
+#include "Kit/System/printfchecker.h"
 #include <stdarg.h>
 #include <iostream>
 
@@ -312,14 +313,17 @@ public:
 
         NOTE: if 'format' is null, then nothing is done
      */
+    KIT_SYSTEM_PRINTF_CHECKER( 2, 3 )
     virtual void format( const char* format, ... ) noexcept = 0;
 
     /// Same as format() - but appends "formatting" to the end of the string
+    KIT_SYSTEM_PRINTF_CHECKER( 2, 3 )
     virtual void formatAppend( const char* format, ... ) noexcept = 0;
 
     /** This method is the same as format(), except when 'appendFlag' is true
         then it behaves as formatAppend().
      */
+    KIT_SYSTEM_PRINTF_CHECKER( 3, 4 )
     virtual void formatOpt( bool appendFlag, const char* format, ... ) noexcept = 0;
 
 

--- a/src/Kit/Text/StringBase.h
+++ b/src/Kit/Text/StringBase.h
@@ -88,12 +88,15 @@ public:
     bool endsWith( const char* string ) const noexcept;
 
     /// See Kit::Text::IString
+    KIT_SYSTEM_PRINTF_CHECKER( 2, 3 )
     void format( const char* format, ... ) noexcept;
 
     /// See Kit::Text::IString
+    KIT_SYSTEM_PRINTF_CHECKER( 2, 3 )
     void formatAppend( const char* format, ... ) noexcept;
 
     /// See Kit::Text::IString
+    KIT_SYSTEM_PRINTF_CHECKER( 3, 4 )
     void formatOpt( bool appendFlag, const char* format, ... ) noexcept;
 
     /// See Kit::Text::IString

--- a/src/Kit/Text/_0test/istring.cpp
+++ b/src/Kit/Text/_0test/istring.cpp
@@ -289,11 +289,11 @@ TEST_CASE( "IString" )
         bar.formatAppend( "overflow the originally allocated block(s)" );
         REQUIRE( bar == "Bob=FFFFFFFF, was here. 12overf" );
 
-        bar.format( nullPtr );
+        bar.format( nullPtr, 2 );   // the second arg is to get past the KIT_SYSTEM_PRINTF_CHECKER()
         REQUIRE( bar == "Bob=FFFFFFFF, was here. 12overf" );
         bar.format( "bob" );
         REQUIRE( bar == "bob" );
-        bar.formatAppend( nullPtr );
+        bar.formatAppend( nullPtr, 1 );
         REQUIRE( bar == "bob" );
     }
 


### PR DESCRIPTION
- Refactor Fatal Error handler for new `exitCode` argument
- Removed some instances where Fatal Error was being called (instead now the methods return 'fail')
- Added a 'printf-checker' for finding compile time errors for home grown method with printf semantics