### PR TITLE
37 Add ITC abstractions

### DIFF
--- a/src/Kit/EventQueue/IChangeNotification.h
+++ b/src/Kit/EventQueue/IChangeNotification.h
@@ -1,0 +1,69 @@
+#ifndef KIT_EVENT_QUEUE_ICHANGE_NOTIFICATION_H_
+#define KIT_EVENT_QUEUE_ICHANGE_NOTIFICATION_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+
+/// Forward reference to break dependency on the Dm namespace
+namespace Kit {
+namespace Dm {
+class ISubscriber;
+}
+}
+
+
+
+///
+namespace Kit {
+///
+namespace EventQueue {
+
+
+/** This abstract class defines the interface to manage Data Model Change
+    notification events that are published to Model Points.
+
+    NOTE: The requirements and/or semantics of Model Point subscription is
+            that Subscriptions, Notifications, and Cancel-of-Subscriptions
+            all happen in a SINGLE thread and that thread is the 'Subscribers'
+            thread.
+
+    NOTE: Use of this interface is RESTRICTED to the Kit::Dm namespace. The 
+          Application (or other namespaces) should NEVER use this interface
+ */
+class IChangeNotification
+{
+public:
+    /** This method is used add a new 'change notification' to its list
+        of pending change notifications.  Calling this method when the
+        subscriber is already registered for change notification will cause
+        a FATAL ERROR.
+
+        This method IS thread safe.
+     */
+    virtual void addPendingChangingNotification( Kit::Dm::ISubscriber& subscriber ) noexcept = 0;
+
+    /** This method is used remove a pending 'change notification' from its list
+        of pending change notifications.  It is okay to call this method even if
+        the Subscriber is not current registered for change notifications.
+
+        This method IS thread safe.
+     */
+    virtual void removePendingChangingNotification( Kit::Dm::ISubscriber& subscriber ) noexcept = 0;
+
+
+public:
+    /// Virtual destructor
+    virtual ~IChangeNotification() = default;
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/EventQueue/IMsgNotification.h
+++ b/src/Kit/EventQueue/IMsgNotification.h
@@ -1,0 +1,58 @@
+#ifndef KIT_EVENT_QUEUE_IMSG_NOTIFICATION_H_
+#define KIT_EVENT_QUEUE_IMSG_NOTIFICATION_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+
+/// Forward reference to break dependency on the Itc namespace
+namespace Kit {
+namespace Itc {
+class IMessage;
+}
+}
+
+///
+namespace Kit {
+///
+namespace EventQueue {
+
+/** This abstract class represents the interface used to send ITC messages to a
+    ITC mailbox. The ITC messaging has a client-server paradigm which means that
+    this interface is always invoked by the client.
+ */
+class IMsgNotification
+{
+public:
+    /** This operation is called by clients, which wish to send a message
+        to the owner of this mailbox. The message is threaded into the
+        mailbox queue for the mailbox owner to receive, and the operation
+        returns immediately. The client relinquishes ownership of the memory
+        until the message's returnToSender() function is invoked.
+     */
+    virtual void post( Kit::Itc::IMessage& msg ) noexcept = 0;
+
+    /** This operation is called by clients which wish to send a message
+        to the owner of this mailbox, and then block on the client's thread
+        semaphore. First, the message is threaded into the mailbox queue
+        for the mailbox owner to receive. Next, the client waits on its
+        thread semaphore until the semaphore is signaled.
+     */
+    virtual void postSync( Kit::Itc::IMessage& msg ) noexcept = 0;
+
+
+public:
+    /// Virtual destructor
+    virtual ~IMsgNotification() = default;
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/EventQueue/IQueue.h
+++ b/src/Kit/EventQueue/IQueue.h
@@ -1,0 +1,45 @@
+#ifndef KIT_EVENT_QUEUE_IQUEUE_H_
+#define KIT_EVENT_QUEUE_IQUEUE_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "kit_config.h"
+#include "Kit/EventQueue/IMsgNotification.h"
+
+/** Default to supporting BOTH ITC message and Data Model change notifications
+ */
+#ifndef USE_KIT_EVENT_QUEUE_ITC_MSG_ONLY
+#define KIT_EVENT_QUEUE_SUPPORTED_EVENT_TYPES public IMsgNotification, public IChangeNotification
+#include "Kit/EventQueue/IChangeNotification.h"
+
+/// ITC Messages only
+#else
+#define KIT_EVENT_QUEUE_SUPPORTED_EVENT_TYPES public IMsgNotification
+#endif  // end USE_KIT_EVENT_QUEUE_ITC_MSG_ONLY
+
+
+///
+namespace Kit {
+///
+namespace EventQueue {
+
+
+
+/** This abstract class represents an Event Queue where events can be 
+    delivered to.  See README.txt for additional details
+ */
+class IQueue: KIT_EVENT_QUEUE_SUPPORTED_EVENT_TYPES
+{
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/EventQueue/README.txt
+++ b/src/Kit/EventQueue/README.txt
@@ -1,0 +1,21 @@
+/** @namespace Kit::EventQueue
+
+The 'EventQueue' namespace is used to provide a 'common' Event Queue type when there
+are multiple orthogonal sources of events. For example, the KIT library supports
+ITC message and Data Model change notification events.  Neither ITC or the DM
+have direct dependencies on each other - and while MOST applications will use
+both types of events, there is no requirement to always include both in a
+application.
+
+The driving reason to have a 'common' Event Queue type is that to 'send|post'
+an event - a reference to a Event Queue is needed.  Typically objects are
+provided a reference to their Event Queue in their constructor and the reference
+is stored as member variable to the class.  If there was NOT a common Event
+Queue - then a class that uses ITC and DM change notifications would be required
+to 'cache' two different Event Queue references (i.e. this is the case when using
+the CPL library - Cpl::Itc::PostApi vs Cpl::Dm::MailboxServer).
+
+*/  
+
+
+  

--- a/src/Kit/EventQueue/Server.cpp
+++ b/src/Kit/EventQueue/Server.cpp
@@ -1,0 +1,37 @@
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/EventQueue/Server.h"
+
+
+//------------------------------------------------------------------------------
+namespace Kit {
+namespace EventQueue {
+
+
+/////////////////////
+void Server::entry() noexcept
+{
+    startEventLoop();
+    bool run = true;
+    while ( run )
+    {
+        run = waitAndProcessEvents( isPendingMessage() );
+        if ( run )
+        {
+            processMessages();
+        }
+    }
+    stopEventLoop();
+}
+
+}  // end namespace
+}
+//------------------------------------------------------------------------------

--- a/src/Kit/EventQueue/Server.h
+++ b/src/Kit/EventQueue/Server.h
@@ -1,0 +1,50 @@
+#ifndef KIT_EVENT_QUEUE_SERVER_h_
+#define KIT_EVENT_QUEUE_SERVER_h_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/System/EventLoop.h"
+#include "Kit/Itc/Mailbox.h"
+
+
+///
+namespace Kit {
+///
+namespace EventQueue {
+
+/** This concrete class extends the Kit::System::EventLoop interface to include
+    processing events from Event Queue.  Depending on the compile time configuration,
+    the Event Queue adds events such as:
+       1. ITC Messages
+       2. Data Model change notifications
+ */
+class Server : public Kit::Itc::Mailbox,
+               public Kit::System::EventLoop
+{
+public:
+    /** Constructor.  See the Kit::System::EventLoop constructor for description
+        of the method's arguments.
+     */
+    Server( uint32_t                                        timeOutPeriodInMsec = OPTION_KIT_SYSTEM_EVENT_LOOP_TIMEOUT_PERIOD,
+            Kit::Container::SList<Kit::System::IEventFlag>* eventFlagsList      = nullptr ) noexcept
+        : Kit::Itc::Mailbox( *(static_cast<Kit::System::ISignable*>(this)) )
+        , EventLoop( timeOutPeriodInMsec, eventFlagsList )
+    {
+    }
+
+protected:
+    /// See Kit::System::IRunnable
+    void entry() noexcept override;
+
+};
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/EventQueue/WithPeriodicScheduling.cpp
+++ b/src/Kit/EventQueue/WithPeriodicScheduling.cpp
@@ -1,0 +1,60 @@
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/System/PeriodicScheduler.h"
+#include "WithPeriodicScheduling.h"
+
+
+//------------------------------------------------------------------------------
+namespace Kit {
+namespace EventQueue {
+
+///////////////////////
+WithPeriodicScheduling::WithPeriodicScheduling( Interval_T                                      intervals[],
+                                      Hook_T                                          beginThreadProcessing,
+                                      Hook_T                                          endThreadProcessing,
+                                      ReportSlippageFunc_T                            slippageFunc,
+                                      NowFunc_T                                       nowFunc,
+                                      IdleFunc_T                                      idleFunc,
+                                      uint32_t                                        timeOutPeriodInMsec,
+                                      Kit::Container::SList<Kit::System::IEventFlag>* eventFlagsList ) noexcept
+    : Server( timeOutPeriodInMsec, eventFlagsList )
+    , Kit::System::PeriodicScheduler( intervals, beginThreadProcessing, endThreadProcessing, slippageFunc, nowFunc )
+    , m_idleFunc( idleFunc )
+{
+}
+
+void WithPeriodicScheduling::entry() noexcept
+{
+    startEventLoop();
+    beginLoop();
+
+    bool run = true;
+    while ( run )
+    {
+        run = waitAndProcessEvents( isPendingMessage() );
+        if ( run )
+        {
+            bool atLeastOne = executeScheduler();
+            processMessages();
+            if ( m_idleFunc )
+            {
+                ( m_idleFunc )( (m_nowFunc)(), atLeastOne );
+            }
+        }
+    }
+
+    endLoop();
+    stopEventLoop();
+}
+
+}  // end namespace
+}
+//------------------------------------------------------------------------------

--- a/src/Kit/EventQueue/WithPeriodicScheduling.h
+++ b/src/Kit/EventQueue/WithPeriodicScheduling.h
@@ -1,0 +1,75 @@
+#ifndef KIT_EVENT_QUEUE_WITH_PERIODIC_SCHEDULING_H_
+#define KIT_EVENT_QUEUE_WITH_PERIODIC_SCHEDULING_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/EventQueue/Server.h"
+#include "Kit/System/PeriodicScheduler.h"
+
+
+///
+namespace Kit {
+///
+namespace EventQueue {
+
+/** This class extends the Kit::EventQueue::Server class to add periodic scheduling
+    to an event based 'thread'.  The timing resolution of the periodic scheduling
+    is a determined by the 'timingTickInMsec' argument value in the class's
+    constructor.  For example if 'timingTickInMsec' is 10ms then no interval
+    should have a interval duration less than 10ms.
+
+    The order of processing is:
+
+       1. The Event Loop is unblocked.  Any of the following will trigger the
+          Event Loop to 'wake-up'
+          a. A ITC message was posted to its Event Queue
+          b. A Event Flag was signaled
+          c. A Data Model change notification was generated
+          d. The EventLoop tick-timing expired
+       2. All Event Flags are processed.
+       3. The timers and their callbacks (if any timers have expired) are
+          processed.
+       4. The Periodic scheduler's executeScheduler() method is called
+       5. The Event Queue is processed (e.g. ITC messages, DM Change notifications)
+       6. The optional 'Idle' function is called.
+       7. The loop is repeated until there are no expired timers, no event
+          flags, no MP change notifications, and no ITC messages - at which
+          point the thread blocks and waits till the next wake-up-action.
+
+ */
+class WithPeriodicScheduling : public Server, public Kit::System::PeriodicScheduler
+{
+
+public:
+    /** Constructor.  The argument 'timingTickInMsec' specifies the timing
+        resolution that will be used for Kit::Timer::Local Timers AND for the
+        periodic scheduling.
+     */
+    WithPeriodicScheduling( Interval_T                                      intervals[],
+                            Hook_T                                          beginThreadProcessing = nullptr,
+                            Hook_T                                          endThreadProcessing   = nullptr,
+                            ReportSlippageFunc_T                            slippageFunc          = nullptr,
+                            NowFunc_T                                       nowFunc               = Kit::System::ElapsedTime::millisecondsEx,
+                            IdleFunc_T                                      idleFunc              = nullptr,
+                            uint32_t                                        timeOutPeriodInMsec   = OPTION_KIT_SYSTEM_EVENT_LOOP_TIMEOUT_PERIOD,
+                            Kit::Container::SList<Kit::System::IEventFlag>* eventFlagsList        = nullptr ) noexcept;
+
+public:
+    /// See Kit::System::IRunnable
+    void entry() noexcept override;
+
+protected:
+    /// Cache the Idle function pointer
+    IdleFunc_T m_idleFunc;
+};
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/EventQueue/_0test/AsyncClient.h
+++ b/src/Kit/EventQueue/_0test/AsyncClient.h
@@ -1,0 +1,127 @@
+#ifndef TEST_ITC_ASYNCCLIENT_H_
+#define TEST_ITC_ASYNCCLIENT_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Itc/_0test/ITestRequest.h"
+#include "Kit/Itc/OpenCloseSync.h"
+#include "Kit/System/ISignable.h"
+#include "Kit/System/Trace.h"
+#include "Kit/System/Semaphore.h"
+
+/// Example of Asynchronous ITC client
+class AsyncClient : public Kit::Itc::OpenCloseSync, public ITestResponse
+{
+public:
+    static constexpr const char* MYSECT = "_0test";
+    ITestRequest::SAP&           m_serverSAP;
+    ITestRequest::ReadData_T     m_readPayload;
+    ITestResponse::ReadMsg       m_readResponseMsg;
+    ITestRequest::WriteData_T    m_writePayload;
+    ITestResponse::WriteMsg      m_writeResponseMsg;
+    Kit::System::ISignable&      m_mainThread;
+    uint8_t                      m_data;
+    bool                         m_opened;
+    bool                         m_testAbandon;
+    bool                         m_readRspReceived;
+    bool                         m_writeRspReceived;
+
+public:
+    /// Constructor
+    AsyncClient( Kit::EventQueue::IQueue& clientsEventQueue,
+                 ITestRequest::SAP&       serverSAP,
+                 Kit::System::ISignable&  testCaseThread,
+                 bool                     testAbandon = false ) noexcept
+        : Kit::Itc::OpenCloseSync( clientsEventQueue )
+        , m_serverSAP( serverSAP )
+        , m_readPayload()
+        , m_readResponseMsg( *this, clientsEventQueue, serverSAP, m_readPayload )
+        , m_writePayload( 0 )
+        , m_writeResponseMsg( *this, clientsEventQueue, serverSAP, m_writePayload )
+        , m_mainThread( testCaseThread )
+        , m_data( 0 )
+        , m_opened( false )
+        , m_testAbandon( testAbandon )
+        , m_readRspReceived( false )
+        , m_writeRspReceived( false )
+    {
+    }
+
+    /// Destructor
+    ~AsyncClient() noexcept
+    {
+        close();
+        m_readResponseMsg.abandon();
+        m_writeResponseMsg.abandon();
+    }
+
+public:
+    void request( OpenMsg& msg ) noexcept
+    {
+        KIT_SYSTEM_TRACE_FUNC( MYSECT );
+
+        if ( !m_opened )
+        {
+            m_opened                 = true;
+            msg.getPayload().success = true;
+            m_data                   = (uint8_t)( (size_t)( msg.getPayload().args ) );
+
+            m_writeResponseMsg.getRequestMsg().getPayload().srcData = m_data;
+            m_serverSAP.post( m_writeResponseMsg.getRequestMsg() );
+        }
+
+        msg.returnToSender();
+    }
+
+    void request( CloseMsg& msg ) noexcept
+    {
+        KIT_SYSTEM_TRACE_FUNC( MYSECT );
+
+        if ( m_opened )
+        {
+            m_opened                 = false;
+            msg.getPayload().success = true;
+        }
+
+        msg.returnToSender();
+    }
+
+public:
+    /// ReadData Response
+    void response( ReadMsg& msg ) noexcept
+    {
+        auto& payload = msg.getPayload();
+        m_data        = payload.dstData;
+        KIT_SYSTEM_TRACE_MSG( MYSECT, "RSP: Read: dstByte=%u, success=%d", payload.dstData, payload.success );
+        m_readRspReceived = true;
+        m_mainThread.signal();  // Wake up the test case
+    }
+
+    /// Write Response
+    void response( WriteMsg& msg ) noexcept
+    {
+        auto& payload = msg.getPayload();
+        KIT_SYSTEM_TRACE_MSG( MYSECT, "RSP: Write: srcByte=%u, success=%d", payload.srcData, payload.success );
+        m_writeRspReceived = true;
+        m_mainThread.signal();  // Wake up the test case
+
+        if ( m_testAbandon )
+        {
+            // Abandon the read response message
+            m_readResponseMsg.abandon();
+        }
+
+        // Issue a read request
+        m_serverSAP.post( m_readResponseMsg.getRequestMsg() );
+    }
+};
+
+
+#endif  // end header latch

--- a/src/Kit/EventQueue/_0test/ITestRequest.h
+++ b/src/Kit/EventQueue/_0test/ITestRequest.h
@@ -1,0 +1,122 @@
+#ifndef TEST_ITC_ITEST_REQUEST_H_
+#define TEST_ITC_ITEST_REQUEST_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Itc/RequestMessage.h"
+#include "Kit/Itc/ResponseMessage.h"
+#include "Kit/Itc/SAP.h"
+#include <stdint.h>
+
+/** This abstract class define message types and payloads for a set of ITC
+    services. The request() method(s) are to be implemented by a 'service'
+ */
+class ITestRequest
+{
+public:
+    /// SAP for this API
+    typedef Kit::Itc::SAP<ITestRequest> SAP;
+
+public:
+    /** Payload for Message.
+        IN --> data passed to the service
+        OUT--> data returned from the service
+     */
+    struct ReadData_T
+    {
+        /// OUT: Requested byte
+        uint8_t dstData;
+
+        /// OUT: Number of bytes written
+        bool success;
+
+        /// Constructor
+        ReadData_T()
+            : dstData( 0 )
+            , success( false )
+        {
+        }
+    };
+
+
+    /// Message Type:
+    typedef Kit::Itc::RequestMessage<ITestRequest, ReadData_T> ReadMsg;
+
+
+public:
+    /** Payload for Message.
+        IN --> data passed to the service
+        OUT--> data returned from the service
+     */
+    struct WriteData_T
+    {
+        /// IN: Byte to write
+        uint8_t srcData;
+
+        /// OUT: Number of bytes written
+        bool success;
+
+        /// Constructor
+        WriteData_T( uint8_t dataToWrite )
+            : srcData( dataToWrite )
+            , success( false )
+        {
+        }
+    };
+
+
+    /// Message Type:
+    typedef Kit::Itc::RequestMessage<ITestRequest, WriteData_T> WriteMsg;
+
+
+public:
+    /// ITC Request: Read
+    virtual void request( ReadMsg& msg ) noexcept = 0;
+
+    /// ITC Request: Write
+    virtual void request( WriteMsg& msg ) noexcept = 0;
+
+public:
+    ///
+    virtual ~ITestRequest() = default;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+/** This abstract class define response message types for a set of ITC services.
+    The response() method(s) are to be implemented by the 'client'
+ */
+class ITestResponse
+{
+public:
+    /// Response Message Type: Read
+    typedef Kit::Itc::ResponseMessage<ITestResponse,
+                                      ITestRequest,
+                                      ITestRequest::ReadData_T>
+        ReadMsg;
+
+    /// Response Message Type: Write
+    typedef Kit::Itc::ResponseMessage<ITestResponse,
+                                      ITestRequest,
+                                      ITestRequest::WriteData_T>
+        WriteMsg;
+
+public:
+    /// Response: ReadMsg
+    virtual void response( ReadMsg& msg ) noexcept = 0;
+
+    /// Response: WriteMsg
+    virtual void response( WriteMsg& msg ) noexcept = 0;
+
+public:
+    /// Virtual destructor
+    virtual ~ITestResponse() = default;
+};
+
+#endif  // end header latch

--- a/src/Kit/EventQueue/_0test/_0build/.gitignore
+++ b/src/Kit/EventQueue/_0test/_0build/.gitignore
@@ -1,0 +1,30 @@
+# Misc
+.html-report/
+.coverage.info
+cobertura.json
+jenkins-gcovr.xml
+*.gcov
+_posix64/
+_posix/
+_win32/
+_win64/
+_stm32/
+_arduino/
+ratt.log*
+
+# more stuff
+make.log
+*.gcda
+*.gcno
+*.idb
+*.pdb
+*.ilk
+*.lst
+*.map
+
+# visual studio
+*.ilk
+*.pdb
+*.sln
+
+*.user

--- a/src/Kit/EventQueue/_0test/_0build/libdirs.b
+++ b/src/Kit/EventQueue/_0test/_0build/libdirs.b
@@ -1,0 +1,14 @@
+src/Kit/EventQueue
+src/Kit/EventQueue/_0test
+src/Kit/Itc
+
+src/Kit/Container
+src/Kit/System
+src/Kit/System/_trace
+src/Kit/System/_trace/_stdout
+src/Kit/Io
+src/Kit/Text
+
+src/Kit/System/_testsupport
+src/Kit/Memory/_testsupport
+

--- a/src/Kit/EventQueue/_0test/_0build/linux/gcc-host/build_catch2.py
+++ b/src/Kit/EventQueue/_0test/_0build/linux/gcc-host/build_catch2.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python3
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Get the xpackage root directory from environment variable
+    xpackage_root  = os.environ.get('NQBP_XPKGS_ROOT')
+
+    # Run the "real" script
+    script = os.path.join( xpackage_root, "nqbp2", "other", "compile_catch2_base.py" )
+    cmd = script + " " + " ".join(sys.argv[1:])
+    rc = os.system( cmd )
+    sys.exit( rc )

--- a/src/Kit/EventQueue/_0test/_0build/linux/gcc-host/kit_config.h
+++ b/src/Kit/EventQueue/_0test/_0build/linux/gcc-host/kit_config.h
@@ -1,0 +1,18 @@
+#ifndef KIT_CONFIG_H_
+#define KIT_CONFIG_H_
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Options' (see LConfig Pattern) */
+
+#define USE_KIT_SYSTEM_TRACE
+#define USE_KIT_SYSTEM_ASSERT_MACRO
+#define KitTextToStringMaxUnsigned_T uint64_t
+
+#define USE_KIT_EVENT_QUEUE_ITC_MSG_ONLY
+#endif

--- a/src/Kit/EventQueue/_0test/_0build/linux/gcc-host/kit_map.h
+++ b/src/Kit/EventQueue/_0test/_0build/linux/gcc-host/kit_map.h
@@ -1,0 +1,22 @@
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Mappings'  
+
+          Note: Intentionally there is NO Header latch (see LHeader Pattern)
+                for why.
+*/
+
+// OSAL mappings
+#include "Kit/System/Posix/mappings.h"
+
+// strapi mapping
+#include "Kit/Text/_mappings/_posix/strapi.h"
+
+// IO mapping
+#include "Kit/Io/_mappings/_posix/mappings.h"

--- a/src/Kit/EventQueue/_0test/_0build/linux/gcc-host/libdirs.b
+++ b/src/Kit/EventQueue/_0test/_0build/linux/gcc-host/libdirs.b
@@ -1,0 +1,3 @@
+# Use common (across compilers) libdirs.b
+../libdirs.b
+../../libdirs.b

--- a/src/Kit/EventQueue/_0test/_0build/linux/gcc-host/mytoolchain.py
+++ b/src/Kit/EventQueue/_0test/_0build/linux/gcc-host/mytoolchain.py
@@ -1,0 +1,124 @@
+#---------------------------------------------------------------------------
+# This python module is used to customize a supported toolchain for your 
+# project specific settings.
+#
+# Notes:
+#    - ONLY edit/add statements in the sections marked by BEGIN/END EDITS
+#      markers.
+#    - Maintain indentation level and use spaces (it's a python thing) 
+#    - rvalues must be enclosed in quotes (single ' ' or double " ")
+#    - The structure/class 'BuildValues' contains (at a minimum the
+#      following data members.  Any member not specifically set defaults
+#      to null/empty string
+#            .inc             # C/C++ search path include directories 
+#            .asminc          # Assembly search path include directories
+#            .c_only_flags    # C only compiler flags
+#            .cflags          # C and C++ compiler flags
+#            .cppflags        # C++ only compiler flags
+#            .asmflags        # Assembly compiler flags
+#            .linkflags       # Linker flags
+#            .linklibs        # Linker libraries
+#            .firstobjs       # Object files to be unconditionally linked first
+#            .lastobjs        # Object files to be unconditionally linked last
+#           
+#---------------------------------------------------------------------------
+
+# get definition of the Options structure
+from nqbplib.base import BuildValues
+from nqbplib.my_globals import *
+from nqbplib.utils import config_catch2
+import os, copy
+
+# Capture project/build directory
+prjdir = os.path.dirname(os.path.abspath(__file__))
+
+
+#===================================================
+# BEGIN EDITS/CUSTOMIZATIONS
+#---------------------------------------------------
+
+# Set the name for the final output item
+FINAL_OUTPUT_NAME = 'a.out'
+
+# Using Catch2
+(catch2_inc, catch2_lib, unit_test_objects) = config_catch2( prjdir, 'linux/gcc-host', 'a' )
+
+
+# 
+# For build config/variant: "posix64" 
+#
+
+# Construct option structs
+base_posix64      = BuildValues()
+optimized_posix64 = BuildValues()
+debug_posix64     = BuildValues()
+
+# Set project specific 'base' (i.e always used) options. Note: Catch2 requires C++17 or newer
+base_posix64.cflags    = '-m64 -std=c++17 -Wall -Werror -x c++ -fprofile-arcs -ftest-coverage -fprofile-update=atomic'
+base_posix64.inc       = catch2_inc
+base_posix64.firstobjs = unit_test_objects
+base_posix64.linkflags = '-m64 -fprofile-arcs'
+base_posix64.linklibs  = f'-lgcov {catch2_lib}'
+
+# Set project specific 'optimized' options
+optimized_posix64.cflags    = '-O3'
+
+# Set project specific 'debug' options
+
+
+#
+# For build config/variant: "posix32"
+#
+
+# Set project specific 'base' (i.e always used) options. Note: Catch2 requires C++17 or newer
+base_posix32           = BuildValues()        # Do NOT comment out this line
+base_posix32.cflags    = '-m32 -std=c++17 -Wall -Werror -x c++ -fprofile-arcs -ftest-coverage -fprofile-update=atomic'
+base_posix32.inc       = catch2_inc
+base_posix32.firstobjs = unit_test_objects
+base_posix32.linkflags = '-m32 -fprofile-arcs'
+base_posix32.linklibs  = f'-lgcov {catch2_lib}'
+
+
+# Set project specific 'optimized' options
+optimized_posix32           = BuildValues()    # Do NOT comment out this line
+optimized_posix32.cflags    = '-O3'
+
+# Set project specific 'debug' options
+debug_posix32           = BuildValues()       # Do NOT comment out this line
+
+
+
+#-------------------------------------------------
+# ONLY edit this section if you are have more than
+# ONE build configuration/variant 
+#-------------------------------------------------
+
+posix32_opts = { 'user_base':base_posix32, 
+                 'user_optimized':optimized_posix32, 
+                 'user_debug':debug_posix32
+               }
+               
+               
+posix64_opts = { 'user_base':base_posix64, 
+                 'user_optimized':optimized_posix64, 
+                 'user_debug':debug_posix64
+               }
+  
+        
+# Add new variant option dictionary to # dictionary of 
+# build variants
+build_variants = { 'posix':posix32_opts,
+                   'posix64':posix64_opts,
+                 }    
+
+#---------------------------------------------------
+# END EDITS/CUSTOMIZATIONS
+#===================================================
+
+# Select Module that contains the desired toolchain
+from nqbplib.toolchains.linux.gcc.console_exe import ToolChain
+
+# Function that instantiates an instance of the toolchain
+def create():
+    tc = ToolChain( FINAL_OUTPUT_NAME, prjdir, build_variants, "posix64" )
+    return tc 

--- a/src/Kit/EventQueue/_0test/_0build/linux/gcc-host/nqbp.py
+++ b/src/Kit/EventQueue/_0test/_0build/linux/gcc-host/nqbp.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+"""Invokes NQBP's mk.py script"""
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+	# Make sure the environment is properly set
+	NQBP_BIN = os.environ.get('NQBP_BIN')
+	if ( NQBP_BIN == None ):
+	    sys.exit( "ERROR: The environment variable NQBP_BIN is not set!" )
+	sys.path.append( NQBP_BIN )
+
+	# Find the Package & Workspace root
+	from nqbplib import utils
+	utils.set_pkg_and_wrkspace_roots(__file__)
+
+	# Call into core/common scripts
+	import mytoolchain
+	from nqbplib import mk
+	mk.build( sys.argv, mytoolchain.create() )
+

--- a/src/Kit/EventQueue/_0test/_0build/linux/gcc-host/sources.b
+++ b/src/Kit/EventQueue/_0test/_0build/linux/gcc-host/sources.b
@@ -1,0 +1,2 @@
+# share a common main
+../../main.cpp

--- a/src/Kit/EventQueue/_0test/_0build/linux/gcc-host/tca2.py
+++ b/src/Kit/EventQueue/_0test/_0build/linux/gcc-host/tca2.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python3
+"""Invokes NQBP's tca2_base.py script.  To run 'TCA2' copy this file to your build directory and the execute it."""
+
+from __future__ import absolute_import
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Make sure the environment is properly set
+    NQBP_BIN = os.environ.get('NQBP_BIN')
+    if ( NQBP_BIN == None ):
+        sys.exit( "ERROR: The environment variable NQBP_BIN is not set!" )
+    sys.path.append( NQBP_BIN )
+
+    # Find the Package & Workspace root
+    from nqbplib import utils
+    utils.set_pkg_and_wrkspace_roots(__file__)
+    here = os.path.dirname(os.path.abspath(__file__))
+
+    # Find the Package & Workspace root
+    from other import tca2_base
+    tca2_base.run( here, sys.argv )
+

--- a/src/Kit/EventQueue/_0test/_0build/linux/libdirs.b
+++ b/src/Kit/EventQueue/_0test/_0build/linux/libdirs.b
@@ -1,0 +1,6 @@
+# Platform
+src/Kit/System/Posix
+src/Kit/System/Posix/_fatalerror
+src/Kit/Text/_mappings/_posix
+src/Kit/System/Posix/_realtime
+src/Kit/Io/Stdio/_posix

--- a/src/Kit/EventQueue/_0test/_0build/main.cpp
+++ b/src/Kit/EventQueue/_0test/_0build/main.cpp
@@ -1,0 +1,17 @@
+#include "Kit/System/api.h"
+#include "Kit/System/Trace.h"
+#include "catch2/catch_session.hpp"
+
+int main( int argc, char* argv[] )
+{
+    // Initialize KIT Library
+    Kit::System::initialize();
+
+    // Enable trace
+    KIT_SYSTEM_TRACE_ENABLE();
+    KIT_SYSTEM_TRACE_ENABLE_SECTION( "_0test" );
+    KIT_SYSTEM_TRACE_SET_INFO_LEVEL( Kit::System::Trace::eINFO );
+
+    // Run the test(s)
+    return Catch::Session().run( argc, argv );
+}

--- a/src/Kit/EventQueue/_0test/_0build/windows/gcc-host/build_catch2.py
+++ b/src/Kit/EventQueue/_0test/_0build/windows/gcc-host/build_catch2.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python3
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Get the xpackage root directory from environment variable
+    xpackage_root  = os.environ.get('NQBP_XPKGS_ROOT')
+
+    # Run the "real" script
+    script = os.path.join( xpackage_root, "nqbp2", "other", "compile_catch2_base.py" )
+    cmd = script + " " + " ".join(sys.argv[1:])
+    rc = os.system( cmd )
+    sys.exit( rc )

--- a/src/Kit/EventQueue/_0test/_0build/windows/gcc-host/kit_config.h
+++ b/src/Kit/EventQueue/_0test/_0build/windows/gcc-host/kit_config.h
@@ -1,0 +1,19 @@
+#ifndef KIT_CONFIG_H_
+#define KIT_CONFIG_H_
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Options' (see LConfig Pattern) */
+
+#define USE_KIT_SYSTEM_TRACE
+#define USE_KIT_SYSTEM_ASSERT_MACRO
+#define KitTextToStringMaxUnsigned_T uint64_t
+
+#define USE_KIT_EVENT_QUEUE_ITC_MSG_ONLY
+
+#endif

--- a/src/Kit/EventQueue/_0test/_0build/windows/gcc-host/kit_map.h
+++ b/src/Kit/EventQueue/_0test/_0build/windows/gcc-host/kit_map.h
@@ -1,0 +1,22 @@
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Mappings'  
+
+          Note: Intentionally there is NO Header latch (see LHeader Pattern)
+                for why.
+*/
+
+// OSAL mappings
+#include "Kit/System/Win32/mappings.h"
+
+// strapi mapping
+#include "Kit/Text/_mappings/_mingw/strapi.h"
+
+// IO mapping
+#include "Kit/Io/_mappings/_win32/mappings.h"

--- a/src/Kit/EventQueue/_0test/_0build/windows/gcc-host/libdirs.b
+++ b/src/Kit/EventQueue/_0test/_0build/windows/gcc-host/libdirs.b
@@ -1,0 +1,3 @@
+# Use common (across compilers) libdirs.b
+../libdirs.b
+../../libdirs.b

--- a/src/Kit/EventQueue/_0test/_0build/windows/gcc-host/mytoolchain.py
+++ b/src/Kit/EventQueue/_0test/_0build/windows/gcc-host/mytoolchain.py
@@ -1,0 +1,124 @@
+#---------------------------------------------------------------------------
+# This python module is used to customize a supported toolchain for your 
+# project specific settings.
+#
+# Notes:
+#    - ONLY edit/add statements in the sections marked by BEGIN/END EDITS
+#      markers.
+#    - Maintain indentation level and use spaces (it's a python thing) 
+#    - The structure/class 'BuildValues' contains (at a minimum the
+#      following data members.  Any member not specifically set defaults
+#      to null/empty string
+#            .inc             # C/C++ search path include directories 
+#            .asminc          # Assembly search path include directories
+#            .c_only_flags    # C only compiler flags
+#            .cflags          # C and C++ compiler flags
+#            .cppflags        # C++ only compiler flags
+#            .asmflags        # Assembly compiler flags
+#            .linkflags       # Linker flags
+#            .linklibs        # Linker libraries
+#            .firstobjs       # Object files to be unconditionally linked first
+#            .lastobjs        # Object files to be unconditionally linked last
+#           
+#---------------------------------------------------------------------------
+
+# get definition of the Options structure
+from nqbplib.base import BuildValues
+from nqbplib.my_globals import *
+from nqbplib.utils import config_catch2
+import os, copy 
+
+# Capture project/build directory
+prjdir = os.path.dirname(os.path.abspath(__file__))
+
+#===================================================
+# BEGIN EDITS/CUSTOMIZATIONS
+#---------------------------------------------------
+
+# Set the name for the final output item
+FINAL_OUTPUT_NAME = 'a.exe'
+
+# Using Catch2 
+(catch2_inc, catch2_lib, unit_test_objects) = config_catch2( prjdir, r'windows\gcc-host', 'a' )
+
+
+
+#
+# For build config/variant: "win32"
+#
+
+# Set project specific 'base' (i.e always used) options. Note: Catch2 requires C++17 or newer
+base_win32           = BuildValues()        # Do NOT comment out this line
+base_win32.cflags    = '-m32 -std=c++17 -Wall -Werror -x c++  -fprofile-arcs -ftest-coverage -fprofile-update=atomic'
+base_win32.inc       = catch2_inc
+base_win32.linkflags = '-m32 -fprofile-arcs'
+base_win32.linklibs  = f'-lgcov {catch2_lib}'
+base_win32.firstobjs = unit_test_objects
+
+# Set project specific 'optimized' options
+optimized_win32           = BuildValues()    # Do NOT comment out this line
+optimized_win32.cflags    = '-O3'
+
+# Set project specific 'debug' options
+debug_win32           = BuildValues()       # Do NOT comment out this line
+
+
+#
+# For build config/variant: "win64"
+#
+
+# Construct option structs
+base_win64      = BuildValues()
+optimized_win64 = BuildValues()
+debug_win64     = BuildValues()
+
+# Set 'base' options
+base_win64.cflags     = '-m64 -std=c++17 -Wall -Werror -x c++ -fprofile-arcs -ftest-coverage -fprofile-update=atomic'
+base_win64.inc        = catch2_inc
+base_win64.linkflags  = '-m64'
+base_win64.firstobjs  = unit_test_objects
+base_win64.linklibs   = f'-lgcov {catch2_lib}'
+
+# Set 'Optimized' options
+optimized_win64.cflags    = '-O3'
+
+# Set 'debug' options
+
+
+
+#-------------------------------------------------
+# ONLY edit this section if you are have more than
+# ONE build configuration/variant 
+#-------------------------------------------------
+
+win32_opts = { 'user_base':base_win32, 
+               'user_optimized':optimized_win32, 
+               'user_debug':debug_win32
+             }
+               
+# Add new dictionary of for new build configuration options
+win64_opts = { 'user_base':base_win64,
+               'user_optimized':optimized_win64,
+               'user_debug':debug_win64
+             }
+               
+        
+# Add new variant option dictionary to # dictionary of 
+# build variants
+build_variants = { 'win32':win32_opts,
+                   'win64':win64_opts,
+                 }    
+
+
+#---------------------------------------------------
+# END EDITS/CUSTOMIZATIONS
+#===================================================
+
+# Select Module that contains the desired toolchain
+from nqbplib.toolchains.windows.mingw_w64.console_exe import ToolChain
+
+
+# Function that instantiates an instance of the toolchain
+def create():
+    tc = ToolChain( FINAL_OUTPUT_NAME, prjdir, build_variants, "win32" )
+    return tc 

--- a/src/Kit/EventQueue/_0test/_0build/windows/gcc-host/nqbp.py
+++ b/src/Kit/EventQueue/_0test/_0build/windows/gcc-host/nqbp.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+"""Invokes NQBP's mk.py script"""
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+	# Make sure the environment is properly set
+	NQBP_BIN = os.environ.get('NQBP_BIN')
+	if ( NQBP_BIN == None ):
+	    sys.exit( "ERROR: The environment variable NQBP_BIN is not set!" )
+	sys.path.append( NQBP_BIN )
+
+	# Find the Package & Workspace root
+	from nqbplib import utils
+	utils.set_pkg_and_wrkspace_roots(__file__)
+
+	# Call into core/common scripts
+	import mytoolchain
+	from nqbplib import mk
+	mk.build( sys.argv, mytoolchain.create() )
+

--- a/src/Kit/EventQueue/_0test/_0build/windows/gcc-host/sources.b
+++ b/src/Kit/EventQueue/_0test/_0build/windows/gcc-host/sources.b
@@ -1,0 +1,2 @@
+# share a common main
+../../main.cpp

--- a/src/Kit/EventQueue/_0test/_0build/windows/libdirs.b
+++ b/src/Kit/EventQueue/_0test/_0build/windows/libdirs.b
@@ -1,0 +1,6 @@
+# Platform
+src/Kit/System/Win32
+src/Kit/System/Win32/_shutdown
+src/Kit/System/Win32/_fatalerror
+src/Kit/System/Win32/_realtime
+src/Kit/Io/Stdio/_win32

--- a/src/Kit/EventQueue/_0test/_0build/windows/msvc/build_catch2.py
+++ b/src/Kit/EventQueue/_0test/_0build/windows/msvc/build_catch2.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python3
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Get the xpackage root directory from environment variable
+    xpackage_root  = os.environ.get('NQBP_XPKGS_ROOT')
+
+    # Run the "real" script
+    script = os.path.join( xpackage_root, "nqbp2", "other", "compile_catch2_base.py" )
+    cmd = script + " " + " ".join(sys.argv[1:])
+    rc = os.system( cmd )
+    sys.exit( rc )

--- a/src/Kit/EventQueue/_0test/_0build/windows/msvc/kit_config.h
+++ b/src/Kit/EventQueue/_0test/_0build/windows/msvc/kit_config.h
@@ -1,0 +1,18 @@
+#ifndef KIT_CONFIG_H_
+#define KIT_CONFIG_H_
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Options' (see LConfig Pattern) */
+
+#define USE_KIT_SYSTEM_ASSERT_MACRO
+#define KitTextToStringMaxUnsigned_T uint64_t
+
+#define USE_KIT_EVENT_QUEUE_ITC_MSG_ONLY
+
+#endif

--- a/src/Kit/EventQueue/_0test/_0build/windows/msvc/kit_map.h
+++ b/src/Kit/EventQueue/_0test/_0build/windows/msvc/kit_map.h
@@ -1,0 +1,23 @@
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Mappings'  
+
+          Note: Intentionally there is NO Header latch (see LHeader Pattern)
+                for why.
+*/
+
+
+// OSAL mappings
+#include "Kit/System/Win32/mappings.h"
+
+// strapi mapping
+#include "Kit/Text/_mappings/_msvc/strapi.h"
+
+// IO mapping
+#include "Kit/Io/_mappings/_win32/mappings.h"

--- a/src/Kit/EventQueue/_0test/_0build/windows/msvc/libdirs.b
+++ b/src/Kit/EventQueue/_0test/_0build/windows/msvc/libdirs.b
@@ -1,0 +1,3 @@
+# Use common (across compilers) libdirs.b
+../libdirs.b
+../../libdirs.b

--- a/src/Kit/EventQueue/_0test/_0build/windows/msvc/mytoolchain.py
+++ b/src/Kit/EventQueue/_0test/_0build/windows/msvc/mytoolchain.py
@@ -1,0 +1,91 @@
+#---------------------------------------------------------------------------
+# This python module is used to customize a supported toolchain for your 
+# project specific settings.
+#
+# Notes:
+#    - ONLY edit/add statements in the sections marked by BEGIN/END EDITS
+#      markers.
+#    - Maintain indentation level and use spaces (it's a python thing) 
+#    - The structure/class 'BuildValues' contains (at a minimum the
+#      following data members.  Any member not specifically set defaults
+#      to null/empty string
+#            .inc             # C/C++ search path include directories 
+#            .asminc          # Assembly search path include directories
+#            .c_only_flags    # C only compiler flags
+#            .cflags          # C and C++ compiler flags
+#            .cppflags        # C++ only compiler flags
+#            .asmflags        # Assembly compiler flags
+#            .linkflags       # Linker flags
+#            .linklibs        # Linker libraries
+#            .firstobjs       # Object files to be unconditionally linked first
+#            .lastobjs        # Object files to be unconditionally linked last
+#           
+#---------------------------------------------------------------------------
+
+# get definition of the Options structure
+from nqbplib.base import BuildValues
+from nqbplib.my_globals import *
+from nqbplib.utils import config_catch2
+import os, copy 
+
+# Capture project/build directory
+prjdir = os.path.dirname(os.path.abspath(__file__))
+
+#===================================================
+# BEGIN EDITS/CUSTOMIZATIONS
+#---------------------------------------------------
+
+# Set the name for the final output item
+FINAL_OUTPUT_NAME = 'a.exe'
+
+# Using Catch2 
+(catch2_inc, catch2_lib, unit_test_objects) = config_catch2( prjdir, r'windows\msvc', 'lib' )
+
+
+#
+# For build config/variant: "win32" 
+#
+
+# Set project specific 'base' (i.e always used) options. Note: Catch2 requires C++17 or newer
+base_win32           = BuildValues()        # Do NOT comment out this line
+base_win32.cflags    = '/W3 /WX /EHsc '  # /EHsc enables exceptions /std:c++17
+base_win32.firstobjs = unit_test_objects
+base_win32.inc       = catch2_inc
+base_win32.linklibs  = catch2_lib
+
+# Set project specific 'optimized' options
+optimized_win32          = BuildValues()    # Do NOT comment out this line
+optimized_win32.cflags   = '/O2'
+
+# Set project specific 'debug' options
+debug_win32          = BuildValues()       # Do NOT comment out this line
+debug_win32.cflags   = '/D "KIT_DEBUG"'
+
+
+#-------------------------------------------------
+# ONLY edit this section if you are have more than
+# ONE build configuration/variant 
+#-------------------------------------------------
+
+win32_build_opts = { 'user_base':base_win32, 
+                     'user_optimized':optimized_win32, 
+                     'user_debug':debug_win32
+                   }
+               
+# Add new variant option dictionary to # dictionary of 
+# build variants
+build_variants = { 'win32':win32_build_opts,
+                 }    
+
+#---------------------------------------------------
+# END EDITS/CUSTOMIZATIONS
+#===================================================
+
+
+# Select Module that contains the desired toolchain
+from nqbplib.toolchains.windows.vc12.console_exe import ToolChain
+
+# Function that instantiates an instance of the toolchain
+def create():
+    tc = ToolChain( FINAL_OUTPUT_NAME, prjdir, build_variants, 'win32' )
+    return tc 

--- a/src/Kit/EventQueue/_0test/_0build/windows/msvc/nqbp.py
+++ b/src/Kit/EventQueue/_0test/_0build/windows/msvc/nqbp.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+"""Invokes NQBP's mk.py script"""
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+	# Make sure the environment is properly set
+	NQBP_BIN = os.environ.get('NQBP_BIN')
+	if ( NQBP_BIN == None ):
+	    sys.exit( "ERROR: The environment variable NQBP_BIN is not set!" )
+	sys.path.append( NQBP_BIN )
+
+	# Find the Package & Workspace root
+	from nqbplib import utils
+	utils.set_pkg_and_wrkspace_roots(__file__)
+
+	# Call into core/common scripts
+	import mytoolchain
+	from nqbplib import mk
+	mk.build( sys.argv, mytoolchain.create() )
+

--- a/src/Kit/EventQueue/_0test/_0build/windows/msvc/sources.b
+++ b/src/Kit/EventQueue/_0test/_0build/windows/msvc/sources.b
@@ -1,0 +1,2 @@
+# share a common main
+../../main.cpp

--- a/src/Kit/EventQueue/_0test/async.cpp
+++ b/src/Kit/EventQueue/_0test/async.cpp
@@ -1,0 +1,156 @@
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+
+#include "Kit/Itc/OpenCloseSync.h"
+#include "Kit/System/_testsupport/ShutdownUnitTesting.h"
+#include "catch2/catch_test_macros.hpp"
+#include "ITestRequest.h"
+#include "AsyncClient.h"
+#include "Kit/EventQueue/Server.h"
+#include "Kit/System/Thread.h"
+#include "Kit/System/api.h"
+
+#define SECT_ "_0test"
+
+///
+using namespace Kit::Itc;
+using namespace Kit::System;
+
+////////////////////////////////////////////////////////////////////////////////
+// Anonymous namespace
+namespace {
+
+// Dummy service to test the OpenSync class
+class MockService : public OpenCloseSync, public ITestRequest
+{
+public:
+    bool    isOpened = false;
+    uint8_t byteVal  = 0;
+    MockService( Kit::EventQueue::IQueue& myEventQueue ) noexcept
+        : OpenCloseSync( myEventQueue )
+        , isOpened( false )
+    {
+    }
+
+public:
+    /// See Kit::Itc::IOpenRequest
+    void request( OpenMsg& msg ) noexcept override
+    {
+        msg.getPayload().success = true;
+        isOpened                 = true;
+        msg.returnToSender();
+    }
+
+    /// See Kit::Itc::IOpenRequest
+    void request( CloseMsg& msg ) noexcept override
+    {
+        msg.getPayload().success = true;
+        isOpened                 = false;
+        msg.returnToSender();
+    }
+
+    void request( ReadMsg& msg ) noexcept override
+    {
+
+        msg.getPayload().success = true;
+        msg.getPayload().dstData = byteVal;
+        KIT_SYSTEM_TRACE_MSG( SECT_, "REQ: Read: dstData=%u, success=%d", msg.getPayload().dstData, msg.getPayload().success );
+        msg.returnToSender();
+    }
+
+    virtual void request( WriteMsg& msg ) noexcept override
+    {
+        KIT_SYSTEM_TRACE_MSG( SECT_, "REQ: Write: srcByte=%u, success=%d", msg.getPayload().srcData, msg.getPayload().success );
+
+        msg.getPayload().success = true;
+        byteVal                  = msg.getPayload().srcData + 1;
+        msg.returnToSender();
+    }
+};
+
+
+}  // end anonymous namespace
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_CASE( "Async" )
+{
+    ShutdownUnitTesting::clearAndUseCounter();
+
+    Kit::EventQueue::Server serverEventLoop;
+    Kit::EventQueue::Server clientEventLoop;
+
+    // Create test threads
+    auto serverThread = Kit::System::Thread::create( serverEventLoop, "ServerThread" );
+    REQUIRE( serverThread != nullptr );
+    auto clientThread = Kit::System::Thread::create( clientEventLoop, "ClientThread" );
+    REQUIRE( clientThread != nullptr );
+
+    SECTION( "happy-path" )
+    {
+        MockService       uutServer( serverEventLoop );
+        ITestRequest::SAP serverSAP( uutServer, serverEventLoop );
+        AsyncClient       uutClient( clientEventLoop, serverSAP, Thread::getCurrent() );
+
+        // Open both client and server. Server MUST be opened first due to hold the test is constructed
+        bool result = uutServer.open();
+        REQUIRE( result == true );
+        REQUIRE( uutServer.isOpened == true );
+        result = uutClient.open( (void*)42 );
+        REQUIRE( result == true );
+        REQUIRE( uutClient.m_opened == true );
+
+        // Wait for the test sequence to complete
+        Thread::wait();
+        Thread::wait();
+
+        REQUIRE( uutServer.byteVal == ( 42 + 1 ) );
+        uutServer.close();
+        REQUIRE( uutServer.isOpened == false );
+        REQUIRE( uutClient.m_readRspReceived == true );
+        REQUIRE( uutClient.m_writeRspReceived == true );
+        uutClient.close();
+        REQUIRE( uutClient.m_opened == false );
+    }
+
+    SECTION( "abandon" )
+    {
+        MockService       uutServer( serverEventLoop );
+        ITestRequest::SAP serverSAP( uutServer, serverEventLoop );
+        AsyncClient       uutClient( clientEventLoop, serverSAP, Thread::getCurrent(), true );
+
+        // Open both client and server. Server MUST be opened first due to hold the test is constructed
+        bool result = uutServer.open();
+        REQUIRE( result == true );
+        REQUIRE( uutServer.isOpened == true );
+        result = uutClient.open( (void*)42 );
+        REQUIRE( result == true );
+        REQUIRE( uutClient.m_opened == true );
+
+        // Wait for the test sequence to complete
+        Thread::wait();
+        Kit::System::sleep( 400 );  // Give time for the read response to arrive at client -->which it won't because it was abandoned
+        REQUIRE( uutServer.byteVal == ( 42 + 1 ) );
+
+        uutServer.close();
+        REQUIRE( uutServer.isOpened == false );
+        REQUIRE( uutClient.m_readRspReceived == false );
+        REQUIRE( uutClient.m_writeRspReceived == true );
+        uutClient.close();
+        REQUIRE( uutClient.m_opened == false );
+    }
+    // Shutdown threads
+    clientEventLoop.pleaseStop();
+    serverEventLoop.pleaseStop();
+    Kit::System::Thread::destroy( *clientThread );
+    Kit::System::Thread::destroy( *serverThread );
+
+    REQUIRE( ShutdownUnitTesting::getAndClearCounter() == 0u );
+}

--- a/src/Kit/EventQueue/_0test/openclose.cpp
+++ b/src/Kit/EventQueue/_0test/openclose.cpp
@@ -1,0 +1,122 @@
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+
+#include "Kit/EventQueue/IQueue.h"
+#include "Kit/Itc/OpenCloseSync.h"
+#include "Kit/System/_testsupport/ShutdownUnitTesting.h"
+#include "catch2/catch_test_macros.hpp"
+#include "Kit/Itc/OpenSync.h"
+#include "Kit/EventQueue/Server.h"
+#include "Kit/System/Thread.h"
+
+///
+using namespace Kit::Itc;
+using namespace Kit::System;
+
+////////////////////////////////////////////////////////////////////////////////
+// Anonymous namespace
+namespace {
+
+// Dummy service to test the OpenSync class
+class MockService : public OpenCloseSync
+{
+public:
+    bool     isOpened       = false;
+    bool     resultOpenMsg  = true;
+    void*    argsOpenMsg    = nullptr;
+    bool     resultCloseMsg = true;
+    void*    argsCloseMsg   = nullptr;
+
+    MockService( Kit::EventQueue::IQueue& myEventQueue ) noexcept
+        : OpenCloseSync( myEventQueue )
+        , isOpened( false )
+    {
+    }
+
+public:
+    /// See Kit::Itc::IOpenRequest
+    void request( OpenMsg& msg ) noexcept override
+    {
+        msg.getPayload().success = resultOpenMsg;
+        argsOpenMsg              = msg.getPayload().args;
+        isOpened                 = true;
+        msg.returnToSender();
+    }
+
+    /// See Kit::Itc::IOpenRequest
+    void request( CloseMsg& msg ) noexcept override
+    {
+        msg.getPayload().success = resultCloseMsg;
+        argsCloseMsg             = msg.getPayload().args;
+        isOpened                 = false;
+        msg.returnToSender();
+    }
+};
+
+
+}  // end anonymous namespace
+
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_CASE( "OpenClose" )
+{
+    ShutdownUnitTesting::clearAndUseCounter();
+
+    Kit::EventQueue::Server uutEventLoop;
+    MockService             uut( uutEventLoop );
+
+    // Create test thread
+    auto testThread = Kit::System::Thread::create( uutEventLoop, "TestThread" );
+    REQUIRE( testThread != nullptr );
+
+    SECTION( "happy-path" )
+    {
+        bool result = uut.open();
+        REQUIRE( result == true );
+        REQUIRE( uut.isOpened == true );
+        REQUIRE( uut.argsOpenMsg == nullptr );
+
+        result = uut.close();
+        REQUIRE( result == true );
+        REQUIRE( uut.isOpened == false );
+        REQUIRE( uut.argsCloseMsg == nullptr );
+    }
+
+    SECTION( "failed-open/close" )
+    {
+        uut.resultOpenMsg  = false;
+        uut.resultCloseMsg = false;
+        bool result = uut.open();
+        REQUIRE( result == false );
+
+        result = uut.close();
+        REQUIRE( result == false );
+    }
+
+    SECTION( "args" )
+    {
+        bool result = uut.open( (void*)1234 );
+        REQUIRE( result == true );
+        REQUIRE( uut.isOpened == true );
+        REQUIRE( uut.argsOpenMsg == (void*)1234 );
+
+        result = uut.close( (void*)12 );
+        REQUIRE( result == true );
+        REQUIRE( uut.isOpened == false );
+        REQUIRE( uut.argsCloseMsg == (void*)12 );
+    }
+
+    // Shutdown threads
+    uutEventLoop.pleaseStop();
+    Kit::System::Thread::destroy( *testThread );
+
+    REQUIRE( ShutdownUnitTesting::getAndClearCounter() == 0u );
+}

--- a/src/Kit/EventQueue/_0test/withperiodicscheduling.cpp
+++ b/src/Kit/EventQueue/_0test/withperiodicscheduling.cpp
@@ -1,0 +1,179 @@
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/EventQueue/WithPeriodicScheduling.h"
+#include "Kit/System/PeriodicScheduler.h"
+#include "Kit/System/_testsupport/ShutdownUnitTesting.h"
+#include "catch2/catch_test_macros.hpp"
+#include "Kit/System/Trace.h"
+#include "Kit/System/Thread.h"
+#include "Kit/System/api.h"
+#include "Kit/EventQueue/WithPeriodicScheduling.h"
+#include <inttypes.h>
+
+#define SECT_                 "_0test"
+
+#define TEST_DURATION_IN_MSEC 250
+
+using namespace Kit::EventQueue;
+using namespace Kit::System;
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+static inline void displayInfo( const char* label, unsigned count, uint64_t currentTick, uint64_t intervalTick, void* context )
+{
+    KIT_SYSTEM_TRACE_MSG( SECT_, "%-7s: %d, tick=%" PRIu32 ", interval=%" PRIu32 ", context=%p", label, count, (uint32_t)currentTick, (uint32_t)intervalTick, context );
+}
+
+
+static uint64_t appleLastCurrentTick_;
+static uint64_t appleLastCurrentInterval_;
+static void*    appleLastContext_;
+static unsigned appleCount_;
+
+static void appleProcessInterval( uint64_t currentTick, uint64_t currentInterval, void* context )
+{
+    appleCount_++;
+    appleLastCurrentTick_     = currentTick;
+    appleLastCurrentInterval_ = currentInterval;
+    appleLastContext_         = context;
+}
+
+static uint64_t orangeLastCurrentTick_;
+static uint64_t orangeLastCurrentInterval_;
+static void*    orangeLastContext_;
+static unsigned orangeCount_;
+
+static void orangeProcessInterval( uint64_t currentTick, uint64_t currentInterval, void* context )
+{
+    orangeCount_++;
+    orangeLastCurrentTick_     = currentTick;
+    orangeLastCurrentInterval_ = currentInterval;
+    orangeLastContext_         = context;
+}
+
+static unsigned slippageCount_;
+static uint64_t slippageLastCurrentTick_;
+static uint64_t slippageLastMissedInterval_;
+static void*    slippageLastContext_;
+static void     reportSlippage( PeriodicScheduler::Interval_T& intervalThatSlipped, uint64_t currentTick, uint64_t missedInterval )
+{
+    slippageCount_++;
+    slippageLastCurrentTick_    = currentTick;
+    slippageLastMissedInterval_ = missedInterval;
+    slippageLastContext_        = intervalThatSlipped.context;
+    displayInfo( "SLIPPAGE", slippageCount_, slippageLastCurrentTick_, slippageLastMissedInterval_, slippageLastContext_ );
+}
+
+static unsigned startLoopCount_;
+static uint64_t startLoopCountLastCurrentTick_;
+static void     loopStart( uint64_t currentTick )
+{
+    startLoopCount_++;
+    startLoopCountLastCurrentTick_ = currentTick;
+}
+
+static unsigned endLoopCount_;
+static uint64_t endLoopCountLastCurrentTick_;
+static void     loopEnd( uint64_t currentTick )
+{
+    endLoopCount_++;
+    endLoopCountLastCurrentTick_ = currentTick;
+}
+
+static unsigned idleCallCount_;
+static uint64_t idleCallCountLastCurrentTick_;
+static void     idleFunc( uint64_t currentTick, bool atLeastOneIntervalExecuted )
+{
+    idleCallCount_++;
+    idleCallCountLastCurrentTick_ = currentTick;
+}
+
+
+static PeriodicScheduler::Interval_T intervals_[] = {
+    { appleProcessInterval, 10, (void*)0xCAFE },
+    { orangeProcessInterval, 100, (void*)0xBEEF },
+    KIT_SYSTEM_PERIODIC_SCHEDULER_END_INTERVALS
+};
+
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_CASE( "EventLoopWithPScheduling" )
+{
+    KIT_SYSTEM_TRACE_FUNC( SECT_ );
+    ShutdownUnitTesting::clearAndUseCounter();
+
+    appleCount_                    = 0;
+    appleLastCurrentTick_          = 0;
+    appleLastCurrentInterval_      = 0;
+    appleLastContext_              = 0;
+    orangeCount_                   = 0;
+    orangeLastCurrentTick_         = 0;
+    orangeLastCurrentInterval_     = 0;
+    orangeLastContext_             = 0;
+    slippageCount_                 = 0;
+    slippageLastCurrentTick_       = 0;
+    slippageLastMissedInterval_    = 0;
+    slippageLastContext_           = 0;
+    startLoopCount_                = 0;
+    startLoopCountLastCurrentTick_ = 0;
+    endLoopCount_                  = 0;
+    endLoopCountLastCurrentTick_   = 0;
+    idleCallCount_                 = 0;
+
+
+    SECTION( "happy path" )
+    {
+        WithPeriodicScheduling uut( intervals_, loopStart, loopEnd, reportSlippage, ElapsedTime::millisecondsEx, idleFunc );
+        Thread*                testThread = Thread::create( uut, "TEST" );
+        REQUIRE( testThread != nullptr );
+        sleep( TEST_DURATION_IN_MSEC );
+        REQUIRE( endLoopCount_ == 0 );
+        uut.pleaseStop();
+
+        REQUIRE( startLoopCount_ == 1 );
+        REQUIRE( appleCount_ >= 10 );
+        REQUIRE( appleCount_ <= ( TEST_DURATION_IN_MSEC / 10 ) + 1 );
+        REQUIRE( orangeCount_ >= 1 );
+        REQUIRE( orangeCount_ <= ( TEST_DURATION_IN_MSEC / 100 ) + 1 );
+        REQUIRE( idleCallCount_ >= 10 );
+        REQUIRE( idleCallCount_ <= ( TEST_DURATION_IN_MSEC / OPTION_KIT_SYSTEM_EVENT_LOOP_TIMEOUT_PERIOD ) + 1 );
+
+        sleep( 100 );
+        REQUIRE( testThread->isActive() == false );
+        REQUIRE( endLoopCount_ == 1 );
+        Thread::destroy( *testThread );
+    }
+
+    SECTION( "no-idle-func" )
+    {
+        WithPeriodicScheduling uut( intervals_, loopStart, loopEnd, reportSlippage, ElapsedTime::millisecondsEx );
+        Thread*                testThread = Thread::create( uut, "TEST" );
+        REQUIRE( testThread != nullptr );
+        sleep( TEST_DURATION_IN_MSEC );
+        REQUIRE( endLoopCount_ == 0 );
+        uut.pleaseStop();
+
+        REQUIRE( startLoopCount_ == 1 );
+        REQUIRE( appleCount_ >= 10 );
+        REQUIRE( appleCount_ <= ( TEST_DURATION_IN_MSEC / 10 ) + 1 );
+        REQUIRE( orangeCount_ >= 1 );
+        REQUIRE( orangeCount_ <= ( TEST_DURATION_IN_MSEC / 100 ) + 1 );
+        REQUIRE( idleCallCount_ == 0 );
+
+        sleep( 100 );
+        REQUIRE( testThread->isActive() == false );
+        REQUIRE( endLoopCount_ == 1 );
+        Thread::destroy( *testThread );
+    }
+
+    REQUIRE( ShutdownUnitTesting::getAndClearCounter() == 0u );
+}

--- a/src/Kit/Itc/AsyncReturnHandler.h
+++ b/src/Kit/Itc/AsyncReturnHandler.h
@@ -1,0 +1,66 @@
+#ifndef KIT_ITC_ASYNC_RETURN_HANDLER_H_
+#define KIT_ITC_ASYNC_RETURN_HANDLER_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/EventQueue/IQueue.h"
+#include "Kit/Itc/IReturnHandler.h"
+#include <type_traits>
+
+
+/// Compile time check for the EventQueue being configured 'correctly'
+static_assert( std::is_base_of<Kit::EventQueue::IMsgNotification, Kit::EventQueue::IQueue>::value,
+               "IQueue must inherit from IMsgNotification" );
+
+
+///
+namespace Kit {
+///
+namespace Itc {
+
+
+/** This class implements an asynchronous ReturnHandler. When the rts() method
+    of the message associated with this class is invoked, the message referenced
+    as a member variable of this class is posted to the mailbox referenced as
+    a member variable of this class. It is expected that the referenced event
+    loop belongs to the client (i.e. the sender of the original message), and that
+    the message contains a reference to the original message, such that the
+    original message can be released by the client.
+ */
+class AsyncReturnHandler : public IReturnHandler
+{
+public:
+    /** The constructor initializes the response mailbox and message references.
+     */
+    AsyncReturnHandler( Kit::EventQueue::IQueue& clientEventQueue, IMessage& msg ) noexcept
+        : m_clientEventQueue( clientEventQueue )
+        , m_responseMsg( msg )
+    {
+    }
+
+
+public:
+    /// See Kit::Itc::IReturnHandler
+    void rts() noexcept override
+    {
+        m_clientEventQueue.post( m_responseMsg );
+    }
+
+protected:
+    /// Refers to the eventLoop/thread to which the response message will be posted.
+    EventQueue::IQueue& m_clientEventQueue;
+
+    /// Refers to the response message to be posted to the response mailbox.
+    IMessage& m_responseMsg;
+};
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Itc/CloseApi.h
+++ b/src/Kit/Itc/CloseApi.h
@@ -1,0 +1,49 @@
+#ifndef Cpl_Itc_CloseApi_h_
+#define Cpl_Itc_CloseApi_h_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+
+///
+namespace Cpl {
+///
+namespace Itc {
+
+/** This abstract class defines an close interface.  This close interface
+    provides the ability to run an "clean-up/close" routine for a
+    ITC server object IN its native thread (i.e. the thread that the
+    ITC server object executes its ITC requests in).  The close call
+    is a SYNCHRONOUS ITC call.  This has the following effects/requirements:
+
+    1) The caller MUST be in a different thread than the thread of the object
+       being closed.
+
+    2) The thread of the caller will block until the ITC server object
+       has completed its clean-up (i.e. called returnToSender() on
+       the Close Request message).
+ */
+class CloseApi
+{
+public:
+    /** Synchronously closes/cleans-up the called object. The method returns
+        if the close operation was successful.
+     */
+    virtual bool close( void* args = nullptr ) = 0;
+
+
+public:
+    /// Virtual destructor
+    virtual ~CloseApi() {}
+};
+
+
+}      // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Itc/IClose.h
+++ b/src/Kit/Itc/IClose.h
@@ -1,0 +1,49 @@
+#ifndef KIT_ITC_ICLOSE_H_
+#define KIT_ITC_ICLOSE_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+
+///
+namespace Kit {
+///
+namespace Itc {
+
+/** This abstract class defines an close interface.  This close interface
+    provides the ability to run an "shutdown/close" routine for a ITC server
+    object IN its execution thread (i.e. the thread that the ITC server object
+    executes its ITC requests in).  The close call is a SYNCHRONOUS ITC call.
+    This has the following effects/requirements:
+
+    1) The caller MUST be in a different thread than the thread of the object
+       being  closed.
+
+    2) The thread of the caller will block until the ITC server object
+       has completed its initialization (i.e. called returnToSender() on
+       the Close Request message).
+ */
+class IClose
+{
+public:
+    /** Synchronously closes/shutdowns the called object. The method returns
+        if the close operation was successful.
+     */
+    virtual bool close( void* args = nullptr ) noexcept = 0;
+
+
+public:
+    /// Virtual destructor
+    virtual ~IClose() = default;
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Itc/ICloseRequest.h
+++ b/src/Kit/Itc/ICloseRequest.h
@@ -1,0 +1,92 @@
+#ifndef KIT_ITC_ICLOSE_REQUEST_h_
+#define KIT_ITC_ICLOSE_REQUEST_h_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Itc/RequestMessage.h"
+#include "Kit/Itc/ResponseMessage.h"
+#include "Kit/Itc/SAP.h"
+
+///
+namespace Kit {
+///
+namespace Itc {
+
+/** This abstract class defines message types and payloads for a set of ITC
+    services. The request() method(s) are to be implemented by a 'service'
+ */
+class ICloseRequest
+{
+public:
+    /// SAP for this API
+    typedef Kit::Itc::SAP<ICloseRequest> SAP;
+
+public:
+    /// Close Payload
+    struct ClosePayload_T
+    {
+        /// IN: Optional arguments
+        void* args;
+
+        /// OUT: Pass/Fail result of the close request
+        bool success;
+
+        /// Constructor
+        ClosePayload_T( void* args = nullptr )
+            : args( args )
+            , success( false )
+        {
+        }
+    };
+
+
+    /// Message Type: Close
+    typedef RequestMessage<ICloseRequest, ClosePayload_T> CloseMsg;
+
+public:
+    /// ITC Request: Close
+    virtual void request( CloseMsg& msg ) noexcept = 0;
+
+public:
+    ///
+    virtual ~ICloseRequest() = default;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+/** This abstract class define response message types for a set of ITC services.
+    The response() method(s) are to be implemented by the 'client'
+
+    NOTE: Typically the 'Close Request' is done synchronously.  This interface
+          is provided for completeness for the edge case of doing the Close
+          Request asynchronously.
+ */
+class ICloseResponse
+{
+public:
+    /// Response Message Type: Close
+    typedef ResponseMessage<ICloseResponse,
+                            ICloseRequest,
+                            ICloseRequest::ClosePayload_T>
+        CloseMsg;
+
+
+public:
+    /// Response: CloseMsg
+    virtual void response( CloseMsg& msg ) noexcept = 0;
+
+
+public:
+    /// Virtual destructor
+    virtual ~ICloseResponse() = default;
+};
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Itc/IMessage.h
+++ b/src/Kit/Itc/IMessage.h
@@ -1,0 +1,37 @@
+#ifndef KIT_ITC_IMESSAGE_h_
+#define KIT_ITC_IMESSAGE_h_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Container/ListItem.h"
+
+///
+namespace Kit {
+///
+namespace Itc {
+
+/** This abstract class defines the operations for an ITC message
+ */
+class IMessage : public Kit::Container::ExtendedListItem
+{
+public:
+    /** This abstract operation is invoked by the mailbox owner to cause the
+        message to be processed after it has been retrieved from the mailbox.
+     */
+    virtual void process() noexcept = 0;
+
+public:
+    /// Virtual destructor
+    virtual ~IMessage() = default;
+};
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Itc/IOpen.h
+++ b/src/Kit/Itc/IOpen.h
@@ -1,0 +1,49 @@
+#ifndef KIT_ITC_IOPEN_H_
+#define KIT_ITC_IOPEN_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+
+///
+namespace Kit {
+///
+namespace Itc {
+
+/** This abstract class defines an open interface.  This open interface
+    provides the ability to run an "initialize/open" routine for a
+    ITC server object IN its execution thread (i.e. the thread that the
+    ITC server object executes its ITC requests in).  The open call
+    is a SYNCHRONOUS ITC call.  This has the following effects/requirements:
+
+    1) The caller MUST be in a different thread than the thread of the object
+       being  opened.
+
+    2) The thread of the caller will block until the ITC server object
+       has completed its initialization (i.e. called returnToSender() on
+       the Open Request message).
+ */
+class IOpen
+{
+public:
+    /** Synchronously opens/initializes the called object. Returns true
+        if the open operation was successful
+     */
+    virtual bool open( void* args = nullptr ) noexcept = 0;
+
+
+public:
+    /// Virtual destructor
+    virtual ~IOpen() = default;
+};
+
+
+}      // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Itc/IOpenRequest.h
+++ b/src/Kit/Itc/IOpenRequest.h
@@ -1,0 +1,96 @@
+#ifndef KIT_ITC_IOPEN_REQUEST_h_
+#define KIT_ITC_IOPEN_REQUEST_h_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Itc/RequestMessage.h"
+#include "Kit/Itc/ResponseMessage.h"
+#include "Kit/Itc/SAP.h"
+
+///
+namespace Kit {
+///
+namespace Itc {
+
+/** This abstract class define message types and payloads for a set of ITC
+    services. The request() method(s) are to be implemented by a 'service'
+ */
+class IOpenRequest
+{
+public:
+    /// SAP for this API
+    typedef Kit::Itc::SAP<IOpenRequest> SAP;
+
+public:
+    /** Payload for Message.
+        IN --> data passed to the service
+        OUT--> data returned from the service
+     */
+    struct OpenPayload_T
+    {
+        /// IN: Optional arguments
+        void* args;
+
+        /// OUT: Pass/Fail result of the open request
+        bool success;
+
+        /// Constructor
+        OpenPayload_T( void* args = nullptr )
+            : args( args )
+            , success( false )
+        {
+        }
+    };
+
+
+    /// Message Type: Open
+    typedef RequestMessage<IOpenRequest, OpenPayload_T> OpenMsg;
+
+public:
+    /// ITC Request: Open
+    virtual void request( OpenMsg& msg ) noexcept = 0;
+
+public:
+    ///
+    virtual ~IOpenRequest() = default;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+/** This abstract class define response message types for a set of ITC services.
+    The response() method(s) are to be implemented by the 'client'
+
+    NOTE: Typically the 'Open Request' is done synchronously.  This interface
+          is provided for completeness for the edge case of doing the Open
+          Request asynchronously.
+ */
+class IOpenResponse
+{
+public:
+    /// Response Message Type: Open
+    typedef ResponseMessage<IOpenResponse,
+                            IOpenRequest,
+                            IOpenRequest::OpenPayload_T>
+        OpenMsg;
+
+
+public:
+    /// Response: OpenMsg
+    virtual void response( OpenMsg& msg ) noexcept = 0;
+
+
+public:
+    /// Virtual destructor
+    virtual ~IOpenResponse() = default;
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Itc/IReturnHandler.h
+++ b/src/Kit/Itc/IReturnHandler.h
@@ -1,0 +1,41 @@
+#ifndef KIT_ITC_IRETURN_HANDLER_h_
+#define KIT_ITC_IRETURN_HANDLER_h_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+///
+namespace Kit {
+///
+namespace Itc {
+
+/** This abstract class represents the action that is executed by ITC framework
+    in response to a Service completing the operation requested by a ServerMessage.
+    The ReturnHandler is executed when a Service invokes the returnToSender()
+    operation of the message. Implementations of this class are the responsibility
+    of the client (e.g. the client is using synchronous or asynchronous semantics
+    when issuing the request).
+ */
+class IReturnHandler
+{
+public:
+    /** This abstract operation is invoked when a Service has completed processing
+        the client request message. The child implementations should notify
+        the client that the request is complete.
+     */
+    virtual void rts() noexcept = 0;
+
+public:
+    /// Virtual destructor
+    virtual ~IReturnHandler() = default;
+};
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Itc/Mailbox.cpp
+++ b/src/Kit/Itc/Mailbox.cpp
@@ -1,0 +1,67 @@
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Mailbox.h"
+#include "Kit/System/Thread.h"
+#include "Kit/System/GlobalLock.h"
+#include "Kit/System/SimTick.h"
+
+//------------------------------------------------------------------------------
+namespace Kit {
+namespace Itc {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void Mailbox::post( IMessage& msg ) noexcept
+{
+    // Update my internal FIFO
+    Kit::System::GlobalLock::begin();
+    put( msg );
+    Kit::System::GlobalLock::end();
+
+    // Wake up my event loop to process the message
+    m_eventLoop.signal();
+}
+
+void Mailbox::postSync( IMessage& msg ) noexcept
+{
+    post( msg );
+    KIT_SYSTEM_SIM_TICK_APPLICATION_WAIT();
+    Kit::System::Thread::wait();
+}
+
+
+void Mailbox::processMessages() noexcept
+{
+    // Get the next message
+    Kit::System::GlobalLock::begin();
+    IMessage* msgPtr = get();
+    Kit::System::GlobalLock::end();
+
+    // Dispatch at MOST one message
+    if ( msgPtr )
+    {
+        msgPtr->process();
+    }
+}
+
+
+bool Mailbox::isPendingMessage() noexcept
+{
+    // Get the next message
+    Kit::System::GlobalLock::begin();
+    IMessage* msgPtr = first();
+    Kit::System::GlobalLock::end();
+    return msgPtr != nullptr;
+}
+
+} // end namespace
+}
+//------------------------------------------------------------------------------

--- a/src/Kit/Itc/Mailbox.h
+++ b/src/Kit/Itc/Mailbox.h
@@ -1,0 +1,76 @@
+#ifndef KIT_ITC_MAILBOX_H_
+#define KIT_ITC_MAILBOX_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Itc/IMessage.h"
+#include "Kit/EventQueue/IQueue.h"
+#include "Kit/Container/SList.h"
+#include "Kit/System/ISignable.h"
+#include <type_traits>
+
+/// Compile time check for the EventQueue being configured 'correctly'
+static_assert( std::is_base_of<Kit::EventQueue::IMsgNotification, Kit::EventQueue::IQueue>::value,
+               "IQueue must inherit from IMsgNotification" );
+
+///
+namespace Kit {
+///
+namespace Itc {
+
+/** This mailbox class implements an Inter Thread Communications message
+    queue. There is no limit to the number of messages that can be stored in
+    the queue at any given time since the FIFO queue and the messages uses the
+    intrusive container mechanisms from the Kit::Container namespace.
+ */
+
+class Mailbox : public Kit::EventQueue::IQueue,
+                public Kit::Container::SList<IMessage>
+{
+public:
+    /** Constructor.  The 'myEventLoop' is the event loop for Runnable object
+        (aka the Event Loop) where the messages posted to the Mailbox are
+        RETRIEVED and their process() methods execute in.
+     */
+    Mailbox( Kit::System::ISignable& myEventLoop ) noexcept
+        : m_eventLoop( myEventLoop )
+    {
+    }
+
+
+public:
+    /// See Kit::EventQueue::IMsgNotification
+    void post( IMessage& msg ) noexcept override;
+
+    /// See Kit::EventQueue::IMsgNotification
+    void postSync( IMessage& msg ) noexcept override;
+
+
+protected:
+    /** This operation is used process any pending messages.
+     */
+    virtual void processMessages() noexcept;
+
+
+    /** This method IS thread safe.
+
+        This method returns true if there is at least one queued ITC message
+     */
+    bool isPendingMessage() noexcept;
+
+protected:
+    /// The Event Loop/thread that I wait-on/dispatch-msgs-from
+    Kit::System::ISignable& m_eventLoop;
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Itc/NullReturnHandler.h
+++ b/src/Kit/Itc/NullReturnHandler.h
@@ -1,0 +1,41 @@
+#ifndef KIT_ITC_NULL_RETURN_HANDLER_H_
+#define KIT_ITC_NULL_RETURN_HANDLER_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Itc/IReturnHandler.h"
+
+///
+namespace Kit {
+///
+namespace Itc {
+
+/** This class implements a Null ReturnHandler. This means the message
+    is NEVER returned to the calling thread.
+ */
+class NullReturnHandler : public IReturnHandler
+{
+public:
+    /// Constructor
+    NullReturnHandler() noexcept
+    {
+    }
+
+public:
+    /// See Kit::Itc::IReturnHandler
+    void rts() noexcept override
+    {
+    }
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Itc/OpenCloseSync.cpp
+++ b/src/Kit/Itc/OpenCloseSync.cpp
@@ -1,0 +1,37 @@
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "OpenCloseSync.h"
+#include "Kit/EventQueue/IQueue.h"
+#include "SyncReturnHandler.h"
+
+//------------------------------------------------------------------------------
+namespace Kit {
+namespace Itc {
+
+///////////////////
+OpenCloseSync::OpenCloseSync( Kit::EventQueue::IQueue& myEventQueue ) noexcept
+    : OpenSync( myEventQueue )
+{
+}
+
+///////////////////
+bool OpenCloseSync::close( void* args ) noexcept
+{
+    ClosePayload_T          payload( args );
+    SyncReturnHandler       srh;
+    ICloseRequest::CloseMsg msg( *this, payload, srh );
+    m_eventQueue.postSync( msg );
+    return payload.success;
+}
+
+}  // end namespace
+}
+//------------------------------------------------------------------------------

--- a/src/Kit/Itc/OpenCloseSync.h
+++ b/src/Kit/Itc/OpenCloseSync.h
@@ -1,0 +1,48 @@
+#ifndef KIT_ITC_OPEN_CLOSE_SYNC_H_
+#define KIT_ITC_OPEN_CLOSE_SYNC_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Itc/OpenSync.h"
+#include "Kit/Itc/ICloseRequest.h"
+#include "Kit/Itc/IClose.h"
+
+///
+namespace Kit {
+///
+namespace Itc {
+
+/** This partially concrete class extends the ITC OpenSync class and implements
+    the synchronous ITC close call for the CloseApi.  The subclass is still 
+    required to implement the ITC request() method.
+
+    NOTE: This class is derived from OpenSync -->if you support a close(),
+          call, you better have had an open() call.
+ */
+class OpenCloseSync : public OpenSync, public ICloseRequest, public IClose
+{
+public:
+    /** Constructor.  The 'myEventLoop' is the ITC server object's event loop
+        reference of where the service executes uses to receive request messages.
+     */
+    OpenCloseSync( Kit::EventQueue::IQueue& myEventQueue ) noexcept;
+
+
+public:
+    /// See Kit::Itc::IClose
+    bool close( void* args = nullptr ) noexcept override;
+};
+
+
+
+
+}      // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Itc/OpenSync.cpp
+++ b/src/Kit/Itc/OpenSync.cpp
@@ -1,0 +1,37 @@
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "OpenSync.h"
+#include "Kit/EventQueue/IQueue.h"
+#include "SyncReturnHandler.h"
+
+//------------------------------------------------------------------------------
+namespace Kit {
+namespace Itc {
+
+///////////////////
+OpenSync::OpenSync( Kit::EventQueue::IQueue& myEventQueue ) noexcept
+    : m_eventQueue( myEventQueue )
+{
+}
+
+///////////////////
+bool OpenSync::open( void* args ) noexcept
+{
+    OpenPayload_T     payload( args );
+    SyncReturnHandler srh;
+    OpenMsg           msg( *this, payload, srh );
+    m_eventQueue.postSync( msg );
+    return payload.success;
+}
+
+}  // end namespace
+}
+//------------------------------------------------------------------------------

--- a/src/Kit/Itc/OpenSync.h
+++ b/src/Kit/Itc/OpenSync.h
@@ -1,0 +1,55 @@
+#ifndef KIT_ITC_OPEN_SYNC_H_
+#define KIT_ITC_OPEN_SYNC_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Itc/IOpenRequest.h"
+#include "Kit/Itc/IOpen.h"
+#include "Kit/EventQueue/IQueue.h"
+#include <type_traits>
+
+
+/// Compile time check for the EventQueue being configured 'correctly'
+static_assert( std::is_base_of<Kit::EventQueue::IMsgNotification, Kit::EventQueue::IQueue>::value,
+               "IQueue must inherit from IMsgNotification" );
+
+
+///
+namespace Kit {
+///
+namespace Itc {
+
+
+/** This partially concrete class implements the synchronous ITC open
+    call for the OpenApi.  The subclass is still required to implement the ITC
+    request() method.
+ */
+class OpenSync : public IOpenRequest, public IOpen
+{
+public:
+    /** Constructor.  The 'myEventLoop' is the ITC server object's event loop
+        reference of where the service executes uses to receive request messages.
+     */
+    OpenSync( Kit::EventQueue::IQueue& myEventQueue ) noexcept;
+
+
+public:
+    /// See Kit::Itc::IOpen
+    bool open( void* args = nullptr ) noexcept override;
+
+protected:
+    /// Mailbox (of the server implementing the ITC request() method
+    Kit::EventQueue::IQueue& m_eventQueue;
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Itc/README.txt
+++ b/src/Kit/Itc/README.txt
@@ -1,0 +1,45 @@
+/** @namespace Kit::Itc
+
+The Itc namespace provides classes for message based Inter Thread Communications
+(ITC) as well as Event Flags.  The ITC message mechanism has the following 
+characteristics:
+
+    o The ITC model is a client-server model, where client(s) send messages
+      to server(s).  
+
+    o Messages can be sent asynchronously or synchronously.
+
+    o Data flow between clients and server can be uni-directional or 
+      bi-directional (determined by the application). Because this is
+      inter-thread communication, data can be shared via pointers (if
+      desired) since Clients and Servers share the same address space.
+
+    o Data is shared between clients and server using the concept of a
+      'payload'.  In addition, a convention of ownership is used to
+      provide thread-safe  access to the payload.
+      - A client initially owns the payload, i.e. can access the data
+        in the payload without the use of critical sections.
+      - When a client sends (or posts) a message, there is implicit transfer
+        of ownership of the payload.  After sending the message, the client
+        is obligated to NOT access the payload contents.
+      - When a server received a message, the server now 'owns' the payload
+        and can access the data in the payload without the use of critical
+        sections.
+      - When a server 'returns' a message, there is implicit transfer of
+        ownership of the payload back to the client. After returning the
+        message, the server is obligated to NOT access the payload contents.
+
+    o NO dynamic memory is used.  Clients are responsible for providing all
+      of the memory required for the individual message(s).
+      - This translate to no hard limits to the number of messages a server
+        can receive.  It also means that the application does NOT have to
+        worry about 'overflowing' message queues and/or mailboxes.
+      - Another side effect of the memory paradigm is that there is NO 
+        'broadcast' messages.
+
+    o 100% type safe. Messages and payloads are handled and dispatched with 
+      NO typecasting required.
+*/  
+
+
+  

--- a/src/Kit/Itc/RequestMessage.h
+++ b/src/Kit/Itc/RequestMessage.h
@@ -1,0 +1,74 @@
+#ifndef KIT_ITC_REQUEST_MESSAGE_H_
+#define KIT_ITC_REQUEST_MESSAGE_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Itc/ServerMessage.h"
+#include "Kit/Itc/SAP.h"
+
+
+///
+namespace Kit {
+///
+namespace Itc {
+
+/** This concrete template class represents a service request message to a
+    particular server. The SERVICE argument of the template is the abstract
+    interface of the Service for which this Request message is associated with.
+
+    This is the interface that the message uses to invoke the message operation.
+    By definition, the SERVICE class must have a member function named "request"
+    that returns nothing (void) and has a signature whose argument is a reference
+    to the message defined by this template.
+ */
+template <class SERVICE, class PAYLOAD>
+class RequestMessage : public ServerMessage
+{
+public:
+    /// Constructor
+    RequestMessage( SERVICE& srv, PAYLOAD& payload, IReturnHandler& returnHandler ) noexcept
+        : ServerMessage( returnHandler )
+        , m_srv( srv )
+        , m_payload( payload )
+    {
+    }
+
+    /// Constructor
+    RequestMessage( SAP<SERVICE>& sapsrv, PAYLOAD& payload, IReturnHandler& returnHandler ) noexcept
+        : ServerMessage( returnHandler ), m_srv( sapsrv.getService() ), m_payload( payload )
+    {
+    }
+
+public:
+    /// See Kit::Itc::Message.  This call executes in the Service's thread context.
+    void process() noexcept override
+    {
+        m_srv.request( *this );
+    }
+
+public:
+    /// Returns the payload associated with this request
+    PAYLOAD& getPayload() noexcept 
+    {
+        return m_payload;
+    }
+
+protected:
+    /// Reference to the server interface whose 'request' will be called
+    SERVICE& m_srv;
+
+    /// Reference to the request payload
+    PAYLOAD& m_payload;
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Itc/ResponseMessage.h
+++ b/src/Kit/Itc/ResponseMessage.h
@@ -1,0 +1,113 @@
+#ifndef KIT_ITC_RESPONSE_MESSAGE_H_
+#define KIT_ITC_RESPONSE_MESSAGE_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+
+#include "Kit/Itc/AsyncReturnHandler.h"
+#include "Kit/Itc/RequestMessage.h"
+
+
+///
+namespace Kit {
+///
+namespace Itc {
+
+
+/** This template class represents a client response message, which is posted
+    to the client's mailbox after the corresponding server request message is
+    returned to the client via the server message returnToSender interface. The
+    purpose of this class is to provide a standard model for confirmed
+    asynchronous messages. The SERVICE template argument is the type of the
+    server interface that is used by the corresponding server request message.
+    The CLIENT class type is the interface which is invoked by the response
+    message when the client thread invokes the process routine inherited from
+    the Message class.The CLIENT interface must contain a function named
+    "response", which returns nothing (void) and takes a single argument, which
+    is a reference to this template class type.
+ */
+template <class CLIENT, class SERVICE, class PAYLOAD>
+class ResponseMessage : public IMessage
+{
+public:
+    /// Constructor
+    ResponseMessage( CLIENT& client, EventQueue::IQueue& clientsEventQueue, SERVICE& server, PAYLOAD& payload )
+        : m_client( &client ), m_rh( clientsEventQueue, *this ), m_request( server, payload, m_rh )
+    {
+    }
+
+    /// Constructor
+    ResponseMessage( CLIENT& client, EventQueue::IQueue& clientsEventQueue, SAP<SERVICE>& serverSap, PAYLOAD& payload )
+        : m_client( &client ), m_rh( clientsEventQueue, *this ), m_request( serverSap, payload, m_rh )
+    {
+    }
+
+public:
+    /** This method is use to ABANDON the response message. In this context 'abandoned'
+        means the client's 'response(msg)' method will NEVER be called.  It does
+        NOT mean that request processing is aborted.
+
+        This method should only be used when the client is 'going out of scope'
+        (i.e. called in its destructor). If there is outstanding request/response
+        transaction when the client's destructor is called, failing to call the
+        abandon() method will result in a callback to a non-existing object.
+
+        NOTE: In a perfect world, the client would always wait for all outstanding
+        transactions to complete before its destructor is called. However, in the
+        real world, this is not always possible. Therefore, this method provides
+        a way for the client to 'opt out' of receiving the response callback.
+    
+        This method CAN ONLY be called from the CLIENT thread context.
+     */
+    void abandon() noexcept
+    {
+        m_client = nullptr;
+    }
+
+
+    public:
+    /// See Kit::Itc::Message.  This call executes in the Client's thread context.
+    void process() noexcept override
+    {
+        if ( m_client )
+        {
+            m_client->response( *this );
+        }
+    }
+
+
+public:
+    /// Returns a reference to the contained server-request-message
+    RequestMessage<SERVICE, PAYLOAD>& getRequestMsg()
+    {
+        return m_request;
+    }
+
+    /// Returns a reference the payload associated with this request/response
+    PAYLOAD& getPayload()
+    {
+        return m_request.getPayload();
+    }
+
+protected:
+    /// Reference to the client interface whose "response" method will be called
+    CLIENT* m_client;
+
+    /// Return handler used to deliver the response
+    AsyncReturnHandler m_rh;
+
+    /// I contain the actual instantiated server request message!
+    RequestMessage<SERVICE, PAYLOAD> m_request;
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Itc/SAP.h
+++ b/src/Kit/Itc/SAP.h
@@ -1,0 +1,77 @@
+#ifndef KIT_ITC_SAP_H_
+#define KIT_ITC_SAP_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/EventQueue/IQueue.h"
+#include <type_traits>
+
+
+/// Compile time check for the EventQueue being configured 'correctly'
+static_assert( std::is_base_of<Kit::EventQueue::IMsgNotification, Kit::EventQueue::IQueue>::value,
+               "IQueue must inherit from IMsgNotification" );
+
+
+///
+namespace Kit {
+///
+namespace Itc {
+
+/** This concrete template class represents the interface to a ITC Service
+    Access Point (SAP). A SAP 'binds' a Request API with a Event Queue interface
+    (aka a mailbox). In effect a Service is the 'fully-qualified' identifier for
+    posting a message to a specific Request API.
+ */
+template <class SERVICE>
+class SAP : public Kit::EventQueue::IMsgNotification
+{
+public:
+    /** This constructor requires a reference to the
+        request API and its associated mailbox/post-message
+        API.
+     */
+    SAP( SERVICE& api, Kit::EventQueue::IQueue& eventQueue ) noexcept
+        : m_api( api ), m_eventQueue( eventQueue )
+    {
+    }
+
+public:
+    /// Returns a reference to the associated Kit::Itc::Request instance
+    SERVICE& getService() noexcept
+    {
+        return m_api;
+    }
+
+
+public:
+    /// See Kit::EventQueue::IMsgNotification
+    void post( IMessage& msg ) noexcept override
+    {
+        m_eventQueue.post( msg );
+    }
+
+    /// See Kit::EventQueue::IMsgNotification
+    void postSync( IMessage& msg ) noexcept override
+    {
+        m_eventQueue.postSync( msg );
+    }
+
+protected:
+    /// Reference to the instance that implements the request service
+    SERVICE& m_api;
+
+    /// Reference to the associated post-message/mailbox interface
+    Kit::EventQueue::IQueue& m_eventQueue;
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Itc/ServerMessage.h
+++ b/src/Kit/Itc/ServerMessage.h
@@ -1,0 +1,54 @@
+#ifndef KIT_ITC_SERVER_MESSAGE_h_
+#define KIT_ITC_SERVER_MESSAGE_h_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Itc/IMessage.h"
+#include "Kit/Itc/IReturnHandler.h"
+
+///
+namespace Kit {
+///
+namespace Itc {
+
+/** This partially concrete class represents a defined message, which is posted
+    to a mailbox-server as a request. It includes members which enable the client
+    to be notified when the server thread has completed the request.
+ */
+class ServerMessage : public IMessage
+{
+public:
+    /// Constructor
+    ServerMessage( IReturnHandler& rh ) noexcept
+        : m_rh( rh )
+    {
+    }
+
+    /** This operation is invoked by the server when it has completed the
+        operation implemented as a part of this message. Use of this operation
+        relinquishes the ownership of the message from the server (which invokes
+        the operation) to the client.
+     */
+    inline void returnToSender() noexcept
+    {
+        m_rh.rts();
+    }
+
+protected:
+    /** References the handler which is invoked by the ITC framework when the
+        Server/Service returns ownership of the message to the client.
+     */
+    IReturnHandler& m_rh;
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Itc/SyncReturnHandler.h
+++ b/src/Kit/Itc/SyncReturnHandler.h
@@ -1,0 +1,63 @@
+#ifndef KIT_ITC_SYNC_RETURN_HANDLER_h_
+#define KIT_ITC_SYNC_RETURN_HANDLER_h_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+
+#include "Kit/Itc/IReturnHandler.h"
+#include "Kit/System/ISignable.h"
+#include "Kit/System/Thread.h"
+
+///
+namespace Kit {
+///
+namespace Itc {
+
+/** This class implements a synchronous ReturnHandler. The assumption is that
+    the client sends a message to a server mailbox, and then blocks on the
+    thread's semaphore. When the server thread invokes the rts() method, the
+    thread/semaphore is signaled, and thus the client is notified that it has
+    ownership of the message and that the server has completed processing the
+    message.
+
+    The expected typical usage is to created a SyncReturnHandler on the stack
+    in the client's thread just before the mailbox.postSync() method is called.
+ */
+class SyncReturnHandler : public IReturnHandler
+{
+public:
+    /** The constructor initializes the handler with a reference to the
+        thread semaphore of the current thread.
+     */
+    SyncReturnHandler( Kit::System::ISignable& clientSemaphore = Kit::System::Thread::getCurrent() ) noexcept
+        : m_waiter( clientSemaphore)
+    {
+    }
+
+
+public:
+    /// See ReturnHandler
+    void rts() noexcept override
+    {
+        m_waiter.signal();
+    }
+
+protected:
+    /** Reference to the client thread's thread semaphore which is used
+        to notify the client that the server has completed processing
+        the message.
+     */
+    Kit::System::ISignable& m_waiter;
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Itc/_0test/AsyncClient.h
+++ b/src/Kit/Itc/_0test/AsyncClient.h
@@ -1,0 +1,128 @@
+#ifndef TEST_ITC_ASYNCCLIENT_H_
+#define TEST_ITC_ASYNCCLIENT_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/EventQueue/IQueue.h"
+#include "Kit/Itc/_0test/ITestRequest.h"
+#include "Kit/Itc/OpenCloseSync.h"
+#include "Kit/System/ISignable.h"
+#include "Kit/System/Trace.h"
+#include "Kit/System/Semaphore.h"
+
+/// Example of Asynchronous ITC client
+class AsyncClient : public Kit::Itc::OpenCloseSync, public ITestResponse
+{
+public:
+    static constexpr const char* MYSECT = "_0test";
+    ITestRequest::SAP&           m_serverSAP;
+    ITestRequest::ReadData_T     m_readPayload;
+    ITestResponse::ReadMsg       m_readResponseMsg;
+    ITestRequest::WriteData_T    m_writePayload;
+    ITestResponse::WriteMsg      m_writeResponseMsg;
+    Kit::System::ISignable&      m_mainThread;
+    uint8_t                      m_data;
+    bool                         m_opened;
+    bool                         m_testAbandon;
+    bool                         m_readRspReceived;
+    bool                         m_writeRspReceived;
+
+public:
+    /// Constructor
+    AsyncClient( Kit::EventQueue::IQueue& clientsEventQueue,
+                 ITestRequest::SAP&       serverSAP,
+                 Kit::System::ISignable&  testCaseThread,
+                 bool                     testAbandon = false ) noexcept
+        : Kit::Itc::OpenCloseSync( clientsEventQueue )
+        , m_serverSAP( serverSAP )
+        , m_readPayload()
+        , m_readResponseMsg( *this, clientsEventQueue, serverSAP, m_readPayload )
+        , m_writePayload( 0 )
+        , m_writeResponseMsg( *this, clientsEventQueue, serverSAP, m_writePayload )
+        , m_mainThread( testCaseThread )
+        , m_data( 0 )
+        , m_opened( false )
+        , m_testAbandon( testAbandon )
+        , m_readRspReceived( false )
+        , m_writeRspReceived( false )
+    {
+    }
+
+    /// Destructor
+    ~AsyncClient() noexcept
+    {
+        close();
+        m_readResponseMsg.abandon();
+        m_writeResponseMsg.abandon();
+    }
+
+public:
+    void request( OpenMsg& msg ) noexcept
+    {
+        KIT_SYSTEM_TRACE_FUNC( MYSECT );
+
+        if ( !m_opened )
+        {
+            m_opened                 = true;
+            msg.getPayload().success = true;
+            m_data                   = (uint8_t)( (size_t)( msg.getPayload().args ) );
+
+            m_writeResponseMsg.getRequestMsg().getPayload().srcData = m_data;
+            m_serverSAP.post( m_writeResponseMsg.getRequestMsg() );
+        }
+
+        msg.returnToSender();
+    }
+
+    void request( CloseMsg& msg ) noexcept
+    {
+        KIT_SYSTEM_TRACE_FUNC( MYSECT );
+
+        if ( m_opened )
+        {
+            m_opened                 = false;
+            msg.getPayload().success = true;
+        }
+
+        msg.returnToSender();
+    }
+
+public:
+    /// ReadData Response
+    void response( ReadMsg& msg ) noexcept
+    {
+        auto& payload = msg.getPayload();
+        m_data        = payload.dstData;
+        KIT_SYSTEM_TRACE_MSG( MYSECT, "RSP: Read: dstByte=%u, success=%d", payload.dstData, payload.success );
+        m_readRspReceived = true;
+        m_mainThread.signal();  // Wake up the test case
+    }
+
+    /// Write Response
+    void response( WriteMsg& msg ) noexcept
+    {
+        auto& payload = msg.getPayload();
+        KIT_SYSTEM_TRACE_MSG( MYSECT, "RSP: Write: srcByte=%u, success=%d", payload.srcData, payload.success );
+        m_writeRspReceived = true;
+        m_mainThread.signal();  // Wake up the test case
+
+        if ( m_testAbandon )
+        {
+            // Abandon the read response message
+            m_readResponseMsg.abandon();
+        }
+
+        // Issue a read request
+        m_serverSAP.post( m_readResponseMsg.getRequestMsg() );
+    }
+};
+
+
+#endif  // end header latch

--- a/src/Kit/Itc/_0test/ITestRequest.h
+++ b/src/Kit/Itc/_0test/ITestRequest.h
@@ -1,0 +1,122 @@
+#ifndef TEST_ITC_ITEST_REQUEST_H_
+#define TEST_ITC_ITEST_REQUEST_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Itc/RequestMessage.h"
+#include "Kit/Itc/ResponseMessage.h"
+#include "Kit/Itc/SAP.h"
+#include <stdint.h>
+
+/** This abstract class define message types and payloads for a set of ITC
+    services. The request() method(s) are to be implemented by a 'service'
+ */
+class ITestRequest
+{
+public:
+    /// SAP for this API
+    typedef Kit::Itc::SAP<ITestRequest> SAP;
+
+public:
+    /** Payload for Message.
+        IN --> data passed to the service
+        OUT--> data returned from the service
+     */
+    struct ReadData_T
+    {
+        /// OUT: Requested byte
+        uint8_t dstData;
+
+        /// OUT: Number of bytes written
+        bool success;
+
+        /// Constructor
+        ReadData_T()
+            : dstData( 0 )
+            , success( false )
+        {
+        }
+    };
+
+
+    /// Message Type:
+    typedef Kit::Itc::RequestMessage<ITestRequest, ReadData_T> ReadMsg;
+
+
+public:
+    /** Payload for Message.
+        IN --> data passed to the service
+        OUT--> data returned from the service
+     */
+    struct WriteData_T
+    {
+        /// IN: Byte to write
+        uint8_t srcData;
+
+        /// OUT: Number of bytes written
+        bool success;
+
+        /// Constructor
+        WriteData_T( uint8_t dataToWrite )
+            : srcData( dataToWrite )
+            , success( false )
+        {
+        }
+    };
+
+
+    /// Message Type:
+    typedef Kit::Itc::RequestMessage<ITestRequest, WriteData_T> WriteMsg;
+
+
+public:
+    /// ITC Request: Read
+    virtual void request( ReadMsg& msg ) noexcept = 0;
+
+    /// ITC Request: Write
+    virtual void request( WriteMsg& msg ) noexcept = 0;
+
+public:
+    ///
+    virtual ~ITestRequest() = default;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+/** This abstract class define response message types for a set of ITC services.
+    The response() method(s) are to be implemented by the 'client'
+ */
+class ITestResponse
+{
+public:
+    /// Response Message Type: Read
+    typedef Kit::Itc::ResponseMessage<ITestResponse,
+                                      ITestRequest,
+                                      ITestRequest::ReadData_T>
+        ReadMsg;
+
+    /// Response Message Type: Write
+    typedef Kit::Itc::ResponseMessage<ITestResponse,
+                                      ITestRequest,
+                                      ITestRequest::WriteData_T>
+        WriteMsg;
+
+public:
+    /// Response: ReadMsg
+    virtual void response( ReadMsg& msg ) noexcept = 0;
+
+    /// Response: WriteMsg
+    virtual void response( WriteMsg& msg ) noexcept = 0;
+
+public:
+    /// Virtual destructor
+    virtual ~ITestResponse() = default;
+};
+
+#endif  // end header latch

--- a/src/Kit/Itc/_0test/_0build/.gitignore
+++ b/src/Kit/Itc/_0test/_0build/.gitignore
@@ -1,0 +1,30 @@
+# Misc
+.html-report/
+.coverage.info
+cobertura.json
+jenkins-gcovr.xml
+*.gcov
+_posix64/
+_posix/
+_win32/
+_win64/
+_stm32/
+_arduino/
+ratt.log*
+
+# more stuff
+make.log
+*.gcda
+*.gcno
+*.idb
+*.pdb
+*.ilk
+*.lst
+*.map
+
+# visual studio
+*.ilk
+*.pdb
+*.sln
+
+*.user

--- a/src/Kit/Itc/_0test/_0build/libdirs.b
+++ b/src/Kit/Itc/_0test/_0build/libdirs.b
@@ -1,0 +1,14 @@
+src/Kit/Itc
+src/Kit/Itc/_0test
+src/Kit/EventQueue
+
+src/Kit/Container
+src/Kit/System
+src/Kit/System/_trace
+src/Kit/System/_trace/_stdout
+src/Kit/Io
+src/Kit/Text
+
+src/Kit/System/_testsupport
+src/Kit/Memory/_testsupport
+

--- a/src/Kit/Itc/_0test/_0build/linux/gcc-host/build_catch2.py
+++ b/src/Kit/Itc/_0test/_0build/linux/gcc-host/build_catch2.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python3
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Get the xpackage root directory from environment variable
+    xpackage_root  = os.environ.get('NQBP_XPKGS_ROOT')
+
+    # Run the "real" script
+    script = os.path.join( xpackage_root, "nqbp2", "other", "compile_catch2_base.py" )
+    cmd = script + " " + " ".join(sys.argv[1:])
+    rc = os.system( cmd )
+    sys.exit( rc )

--- a/src/Kit/Itc/_0test/_0build/linux/gcc-host/kit_config.h
+++ b/src/Kit/Itc/_0test/_0build/linux/gcc-host/kit_config.h
@@ -1,0 +1,18 @@
+#ifndef KIT_CONFIG_H_
+#define KIT_CONFIG_H_
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Options' (see LConfig Pattern) */
+
+#define USE_KIT_SYSTEM_TRACE
+#define USE_KIT_SYSTEM_ASSERT_MACRO
+#define KitTextToStringMaxUnsigned_T uint64_t
+
+#define USE_KIT_EVENT_QUEUE_ITC_MSG_ONLY
+#endif

--- a/src/Kit/Itc/_0test/_0build/linux/gcc-host/kit_map.h
+++ b/src/Kit/Itc/_0test/_0build/linux/gcc-host/kit_map.h
@@ -1,0 +1,22 @@
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Mappings'  
+
+          Note: Intentionally there is NO Header latch (see LHeader Pattern)
+                for why.
+*/
+
+// OSAL mappings
+#include "Kit/System/Posix/mappings.h"
+
+// strapi mapping
+#include "Kit/Text/_mappings/_posix/strapi.h"
+
+// IO mapping
+#include "Kit/Io/_mappings/_posix/mappings.h"

--- a/src/Kit/Itc/_0test/_0build/linux/gcc-host/libdirs.b
+++ b/src/Kit/Itc/_0test/_0build/linux/gcc-host/libdirs.b
@@ -1,0 +1,3 @@
+# Use common (across compilers) libdirs.b
+../libdirs.b
+../../libdirs.b

--- a/src/Kit/Itc/_0test/_0build/linux/gcc-host/mytoolchain.py
+++ b/src/Kit/Itc/_0test/_0build/linux/gcc-host/mytoolchain.py
@@ -1,0 +1,124 @@
+#---------------------------------------------------------------------------
+# This python module is used to customize a supported toolchain for your 
+# project specific settings.
+#
+# Notes:
+#    - ONLY edit/add statements in the sections marked by BEGIN/END EDITS
+#      markers.
+#    - Maintain indentation level and use spaces (it's a python thing) 
+#    - rvalues must be enclosed in quotes (single ' ' or double " ")
+#    - The structure/class 'BuildValues' contains (at a minimum the
+#      following data members.  Any member not specifically set defaults
+#      to null/empty string
+#            .inc             # C/C++ search path include directories 
+#            .asminc          # Assembly search path include directories
+#            .c_only_flags    # C only compiler flags
+#            .cflags          # C and C++ compiler flags
+#            .cppflags        # C++ only compiler flags
+#            .asmflags        # Assembly compiler flags
+#            .linkflags       # Linker flags
+#            .linklibs        # Linker libraries
+#            .firstobjs       # Object files to be unconditionally linked first
+#            .lastobjs        # Object files to be unconditionally linked last
+#           
+#---------------------------------------------------------------------------
+
+# get definition of the Options structure
+from nqbplib.base import BuildValues
+from nqbplib.my_globals import *
+from nqbplib.utils import config_catch2
+import os, copy
+
+# Capture project/build directory
+prjdir = os.path.dirname(os.path.abspath(__file__))
+
+
+#===================================================
+# BEGIN EDITS/CUSTOMIZATIONS
+#---------------------------------------------------
+
+# Set the name for the final output item
+FINAL_OUTPUT_NAME = 'a.out'
+
+# Using Catch2
+(catch2_inc, catch2_lib, unit_test_objects) = config_catch2( prjdir, 'linux/gcc-host', 'a' )
+
+
+# 
+# For build config/variant: "posix64" 
+#
+
+# Construct option structs
+base_posix64      = BuildValues()
+optimized_posix64 = BuildValues()
+debug_posix64     = BuildValues()
+
+# Set project specific 'base' (i.e always used) options. Note: Catch2 requires C++17 or newer
+base_posix64.cflags    = '-m64 -std=c++17 -Wall -Werror -x c++ -fprofile-arcs -ftest-coverage -fprofile-update=atomic'
+base_posix64.inc       = catch2_inc
+base_posix64.firstobjs = unit_test_objects
+base_posix64.linkflags = '-m64 -fprofile-arcs'
+base_posix64.linklibs  = f'-lgcov {catch2_lib}'
+
+# Set project specific 'optimized' options
+optimized_posix64.cflags    = '-O3'
+
+# Set project specific 'debug' options
+
+
+#
+# For build config/variant: "posix32"
+#
+
+# Set project specific 'base' (i.e always used) options. Note: Catch2 requires C++17 or newer
+base_posix32           = BuildValues()        # Do NOT comment out this line
+base_posix32.cflags    = '-m32 -std=c++17 -Wall -Werror -x c++ -fprofile-arcs -ftest-coverage -fprofile-update=atomic'
+base_posix32.inc       = catch2_inc
+base_posix32.firstobjs = unit_test_objects
+base_posix32.linkflags = '-m32 -fprofile-arcs'
+base_posix32.linklibs  = f'-lgcov {catch2_lib}'
+
+
+# Set project specific 'optimized' options
+optimized_posix32           = BuildValues()    # Do NOT comment out this line
+optimized_posix32.cflags    = '-O3'
+
+# Set project specific 'debug' options
+debug_posix32           = BuildValues()       # Do NOT comment out this line
+
+
+
+#-------------------------------------------------
+# ONLY edit this section if you are have more than
+# ONE build configuration/variant 
+#-------------------------------------------------
+
+posix32_opts = { 'user_base':base_posix32, 
+                 'user_optimized':optimized_posix32, 
+                 'user_debug':debug_posix32
+               }
+               
+               
+posix64_opts = { 'user_base':base_posix64, 
+                 'user_optimized':optimized_posix64, 
+                 'user_debug':debug_posix64
+               }
+  
+        
+# Add new variant option dictionary to # dictionary of 
+# build variants
+build_variants = { 'posix':posix32_opts,
+                   'posix64':posix64_opts,
+                 }    
+
+#---------------------------------------------------
+# END EDITS/CUSTOMIZATIONS
+#===================================================
+
+# Select Module that contains the desired toolchain
+from nqbplib.toolchains.linux.gcc.console_exe import ToolChain
+
+# Function that instantiates an instance of the toolchain
+def create():
+    tc = ToolChain( FINAL_OUTPUT_NAME, prjdir, build_variants, "posix64" )
+    return tc 

--- a/src/Kit/Itc/_0test/_0build/linux/gcc-host/nqbp.py
+++ b/src/Kit/Itc/_0test/_0build/linux/gcc-host/nqbp.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+"""Invokes NQBP's mk.py script"""
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+	# Make sure the environment is properly set
+	NQBP_BIN = os.environ.get('NQBP_BIN')
+	if ( NQBP_BIN == None ):
+	    sys.exit( "ERROR: The environment variable NQBP_BIN is not set!" )
+	sys.path.append( NQBP_BIN )
+
+	# Find the Package & Workspace root
+	from nqbplib import utils
+	utils.set_pkg_and_wrkspace_roots(__file__)
+
+	# Call into core/common scripts
+	import mytoolchain
+	from nqbplib import mk
+	mk.build( sys.argv, mytoolchain.create() )
+

--- a/src/Kit/Itc/_0test/_0build/linux/gcc-host/sources.b
+++ b/src/Kit/Itc/_0test/_0build/linux/gcc-host/sources.b
@@ -1,0 +1,2 @@
+# share a common main
+../../main.cpp

--- a/src/Kit/Itc/_0test/_0build/linux/gcc-host/tca2.py
+++ b/src/Kit/Itc/_0test/_0build/linux/gcc-host/tca2.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python3
+"""Invokes NQBP's tca2_base.py script.  To run 'TCA2' copy this file to your build directory and the execute it."""
+
+from __future__ import absolute_import
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Make sure the environment is properly set
+    NQBP_BIN = os.environ.get('NQBP_BIN')
+    if ( NQBP_BIN == None ):
+        sys.exit( "ERROR: The environment variable NQBP_BIN is not set!" )
+    sys.path.append( NQBP_BIN )
+
+    # Find the Package & Workspace root
+    from nqbplib import utils
+    utils.set_pkg_and_wrkspace_roots(__file__)
+    here = os.path.dirname(os.path.abspath(__file__))
+
+    # Find the Package & Workspace root
+    from other import tca2_base
+    tca2_base.run( here, sys.argv )
+

--- a/src/Kit/Itc/_0test/_0build/linux/libdirs.b
+++ b/src/Kit/Itc/_0test/_0build/linux/libdirs.b
@@ -1,0 +1,6 @@
+# Platform
+src/Kit/System/Posix
+src/Kit/System/Posix/_fatalerror
+src/Kit/Text/_mappings/_posix
+src/Kit/System/Posix/_realtime
+src/Kit/Io/Stdio/_posix

--- a/src/Kit/Itc/_0test/_0build/main.cpp
+++ b/src/Kit/Itc/_0test/_0build/main.cpp
@@ -1,0 +1,17 @@
+#include "Kit/System/api.h"
+#include "Kit/System/Trace.h"
+#include "catch2/catch_session.hpp"
+
+int main( int argc, char* argv[] )
+{
+    // Initialize KIT Library
+    Kit::System::initialize();
+
+    // Enable trace
+    KIT_SYSTEM_TRACE_ENABLE();
+    KIT_SYSTEM_TRACE_ENABLE_SECTION( "_0test" );
+    KIT_SYSTEM_TRACE_SET_INFO_LEVEL( Kit::System::Trace::eINFO );
+
+    // Run the test(s)
+    return Catch::Session().run( argc, argv );
+}

--- a/src/Kit/Itc/_0test/_0build/windows/gcc-host/build_catch2.py
+++ b/src/Kit/Itc/_0test/_0build/windows/gcc-host/build_catch2.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python3
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Get the xpackage root directory from environment variable
+    xpackage_root  = os.environ.get('NQBP_XPKGS_ROOT')
+
+    # Run the "real" script
+    script = os.path.join( xpackage_root, "nqbp2", "other", "compile_catch2_base.py" )
+    cmd = script + " " + " ".join(sys.argv[1:])
+    rc = os.system( cmd )
+    sys.exit( rc )

--- a/src/Kit/Itc/_0test/_0build/windows/gcc-host/kit_config.h
+++ b/src/Kit/Itc/_0test/_0build/windows/gcc-host/kit_config.h
@@ -1,0 +1,19 @@
+#ifndef KIT_CONFIG_H_
+#define KIT_CONFIG_H_
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Options' (see LConfig Pattern) */
+
+#define USE_KIT_SYSTEM_TRACE
+#define USE_KIT_SYSTEM_ASSERT_MACRO
+#define KitTextToStringMaxUnsigned_T uint64_t
+
+#define USE_KIT_EVENT_QUEUE_ITC_MSG_ONLY
+
+#endif

--- a/src/Kit/Itc/_0test/_0build/windows/gcc-host/kit_map.h
+++ b/src/Kit/Itc/_0test/_0build/windows/gcc-host/kit_map.h
@@ -1,0 +1,22 @@
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Mappings'  
+
+          Note: Intentionally there is NO Header latch (see LHeader Pattern)
+                for why.
+*/
+
+// OSAL mappings
+#include "Kit/System/Win32/mappings.h"
+
+// strapi mapping
+#include "Kit/Text/_mappings/_mingw/strapi.h"
+
+// IO mapping
+#include "Kit/Io/_mappings/_win32/mappings.h"

--- a/src/Kit/Itc/_0test/_0build/windows/gcc-host/libdirs.b
+++ b/src/Kit/Itc/_0test/_0build/windows/gcc-host/libdirs.b
@@ -1,0 +1,3 @@
+# Use common (across compilers) libdirs.b
+../libdirs.b
+../../libdirs.b

--- a/src/Kit/Itc/_0test/_0build/windows/gcc-host/mytoolchain.py
+++ b/src/Kit/Itc/_0test/_0build/windows/gcc-host/mytoolchain.py
@@ -1,0 +1,124 @@
+#---------------------------------------------------------------------------
+# This python module is used to customize a supported toolchain for your 
+# project specific settings.
+#
+# Notes:
+#    - ONLY edit/add statements in the sections marked by BEGIN/END EDITS
+#      markers.
+#    - Maintain indentation level and use spaces (it's a python thing) 
+#    - The structure/class 'BuildValues' contains (at a minimum the
+#      following data members.  Any member not specifically set defaults
+#      to null/empty string
+#            .inc             # C/C++ search path include directories 
+#            .asminc          # Assembly search path include directories
+#            .c_only_flags    # C only compiler flags
+#            .cflags          # C and C++ compiler flags
+#            .cppflags        # C++ only compiler flags
+#            .asmflags        # Assembly compiler flags
+#            .linkflags       # Linker flags
+#            .linklibs        # Linker libraries
+#            .firstobjs       # Object files to be unconditionally linked first
+#            .lastobjs        # Object files to be unconditionally linked last
+#           
+#---------------------------------------------------------------------------
+
+# get definition of the Options structure
+from nqbplib.base import BuildValues
+from nqbplib.my_globals import *
+from nqbplib.utils import config_catch2
+import os, copy 
+
+# Capture project/build directory
+prjdir = os.path.dirname(os.path.abspath(__file__))
+
+#===================================================
+# BEGIN EDITS/CUSTOMIZATIONS
+#---------------------------------------------------
+
+# Set the name for the final output item
+FINAL_OUTPUT_NAME = 'a.exe'
+
+# Using Catch2 
+(catch2_inc, catch2_lib, unit_test_objects) = config_catch2( prjdir, r'windows\gcc-host', 'a' )
+
+
+
+#
+# For build config/variant: "win32"
+#
+
+# Set project specific 'base' (i.e always used) options. Note: Catch2 requires C++17 or newer
+base_win32           = BuildValues()        # Do NOT comment out this line
+base_win32.cflags    = '-m32 -std=c++17 -Wall -Werror -x c++  -fprofile-arcs -ftest-coverage -fprofile-update=atomic'
+base_win32.inc       = catch2_inc
+base_win32.linkflags = '-m32 -fprofile-arcs'
+base_win32.linklibs  = f'-lgcov {catch2_lib}'
+base_win32.firstobjs = unit_test_objects
+
+# Set project specific 'optimized' options
+optimized_win32           = BuildValues()    # Do NOT comment out this line
+optimized_win32.cflags    = '-O3'
+
+# Set project specific 'debug' options
+debug_win32           = BuildValues()       # Do NOT comment out this line
+
+
+#
+# For build config/variant: "win64"
+#
+
+# Construct option structs
+base_win64      = BuildValues()
+optimized_win64 = BuildValues()
+debug_win64     = BuildValues()
+
+# Set 'base' options
+base_win64.cflags     = '-m64 -std=c++17 -Wall -Werror -x c++ -fprofile-arcs -ftest-coverage -fprofile-update=atomic'
+base_win64.inc        = catch2_inc
+base_win64.linkflags  = '-m64'
+base_win64.firstobjs  = unit_test_objects
+base_win64.linklibs   = f'-lgcov {catch2_lib}'
+
+# Set 'Optimized' options
+optimized_win64.cflags    = '-O3'
+
+# Set 'debug' options
+
+
+
+#-------------------------------------------------
+# ONLY edit this section if you are have more than
+# ONE build configuration/variant 
+#-------------------------------------------------
+
+win32_opts = { 'user_base':base_win32, 
+               'user_optimized':optimized_win32, 
+               'user_debug':debug_win32
+             }
+               
+# Add new dictionary of for new build configuration options
+win64_opts = { 'user_base':base_win64,
+               'user_optimized':optimized_win64,
+               'user_debug':debug_win64
+             }
+               
+        
+# Add new variant option dictionary to # dictionary of 
+# build variants
+build_variants = { 'win32':win32_opts,
+                   'win64':win64_opts,
+                 }    
+
+
+#---------------------------------------------------
+# END EDITS/CUSTOMIZATIONS
+#===================================================
+
+# Select Module that contains the desired toolchain
+from nqbplib.toolchains.windows.mingw_w64.console_exe import ToolChain
+
+
+# Function that instantiates an instance of the toolchain
+def create():
+    tc = ToolChain( FINAL_OUTPUT_NAME, prjdir, build_variants, "win32" )
+    return tc 

--- a/src/Kit/Itc/_0test/_0build/windows/gcc-host/nqbp.py
+++ b/src/Kit/Itc/_0test/_0build/windows/gcc-host/nqbp.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+"""Invokes NQBP's mk.py script"""
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+	# Make sure the environment is properly set
+	NQBP_BIN = os.environ.get('NQBP_BIN')
+	if ( NQBP_BIN == None ):
+	    sys.exit( "ERROR: The environment variable NQBP_BIN is not set!" )
+	sys.path.append( NQBP_BIN )
+
+	# Find the Package & Workspace root
+	from nqbplib import utils
+	utils.set_pkg_and_wrkspace_roots(__file__)
+
+	# Call into core/common scripts
+	import mytoolchain
+	from nqbplib import mk
+	mk.build( sys.argv, mytoolchain.create() )
+

--- a/src/Kit/Itc/_0test/_0build/windows/gcc-host/sources.b
+++ b/src/Kit/Itc/_0test/_0build/windows/gcc-host/sources.b
@@ -1,0 +1,2 @@
+# share a common main
+../../main.cpp

--- a/src/Kit/Itc/_0test/_0build/windows/libdirs.b
+++ b/src/Kit/Itc/_0test/_0build/windows/libdirs.b
@@ -1,0 +1,6 @@
+# Platform
+src/Kit/System/Win32
+src/Kit/System/Win32/_shutdown
+src/Kit/System/Win32/_fatalerror
+src/Kit/System/Win32/_realtime
+src/Kit/Io/Stdio/_win32

--- a/src/Kit/Itc/_0test/_0build/windows/msvc/build_catch2.py
+++ b/src/Kit/Itc/_0test/_0build/windows/msvc/build_catch2.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python3
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Get the xpackage root directory from environment variable
+    xpackage_root  = os.environ.get('NQBP_XPKGS_ROOT')
+
+    # Run the "real" script
+    script = os.path.join( xpackage_root, "nqbp2", "other", "compile_catch2_base.py" )
+    cmd = script + " " + " ".join(sys.argv[1:])
+    rc = os.system( cmd )
+    sys.exit( rc )

--- a/src/Kit/Itc/_0test/_0build/windows/msvc/kit_config.h
+++ b/src/Kit/Itc/_0test/_0build/windows/msvc/kit_config.h
@@ -1,0 +1,18 @@
+#ifndef KIT_CONFIG_H_
+#define KIT_CONFIG_H_
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Options' (see LConfig Pattern) */
+
+#define USE_KIT_SYSTEM_ASSERT_MACRO
+#define KitTextToStringMaxUnsigned_T uint64_t
+
+#define USE_KIT_EVENT_QUEUE_ITC_MSG_ONLY
+
+#endif

--- a/src/Kit/Itc/_0test/_0build/windows/msvc/kit_map.h
+++ b/src/Kit/Itc/_0test/_0build/windows/msvc/kit_map.h
@@ -1,0 +1,23 @@
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Mappings'  
+
+          Note: Intentionally there is NO Header latch (see LHeader Pattern)
+                for why.
+*/
+
+
+// OSAL mappings
+#include "Kit/System/Win32/mappings.h"
+
+// strapi mapping
+#include "Kit/Text/_mappings/_msvc/strapi.h"
+
+// IO mapping
+#include "Kit/Io/_mappings/_win32/mappings.h"

--- a/src/Kit/Itc/_0test/_0build/windows/msvc/libdirs.b
+++ b/src/Kit/Itc/_0test/_0build/windows/msvc/libdirs.b
@@ -1,0 +1,3 @@
+# Use common (across compilers) libdirs.b
+../libdirs.b
+../../libdirs.b

--- a/src/Kit/Itc/_0test/_0build/windows/msvc/mytoolchain.py
+++ b/src/Kit/Itc/_0test/_0build/windows/msvc/mytoolchain.py
@@ -1,0 +1,91 @@
+#---------------------------------------------------------------------------
+# This python module is used to customize a supported toolchain for your 
+# project specific settings.
+#
+# Notes:
+#    - ONLY edit/add statements in the sections marked by BEGIN/END EDITS
+#      markers.
+#    - Maintain indentation level and use spaces (it's a python thing) 
+#    - The structure/class 'BuildValues' contains (at a minimum the
+#      following data members.  Any member not specifically set defaults
+#      to null/empty string
+#            .inc             # C/C++ search path include directories 
+#            .asminc          # Assembly search path include directories
+#            .c_only_flags    # C only compiler flags
+#            .cflags          # C and C++ compiler flags
+#            .cppflags        # C++ only compiler flags
+#            .asmflags        # Assembly compiler flags
+#            .linkflags       # Linker flags
+#            .linklibs        # Linker libraries
+#            .firstobjs       # Object files to be unconditionally linked first
+#            .lastobjs        # Object files to be unconditionally linked last
+#           
+#---------------------------------------------------------------------------
+
+# get definition of the Options structure
+from nqbplib.base import BuildValues
+from nqbplib.my_globals import *
+from nqbplib.utils import config_catch2
+import os, copy 
+
+# Capture project/build directory
+prjdir = os.path.dirname(os.path.abspath(__file__))
+
+#===================================================
+# BEGIN EDITS/CUSTOMIZATIONS
+#---------------------------------------------------
+
+# Set the name for the final output item
+FINAL_OUTPUT_NAME = 'a.exe'
+
+# Using Catch2 
+(catch2_inc, catch2_lib, unit_test_objects) = config_catch2( prjdir, r'windows\msvc', 'lib' )
+
+
+#
+# For build config/variant: "win32" 
+#
+
+# Set project specific 'base' (i.e always used) options. Note: Catch2 requires C++17 or newer
+base_win32           = BuildValues()        # Do NOT comment out this line
+base_win32.cflags    = '/W3 /WX /EHsc '  # /EHsc enables exceptions /std:c++17
+base_win32.firstobjs = unit_test_objects
+base_win32.inc       = catch2_inc
+base_win32.linklibs  = catch2_lib
+
+# Set project specific 'optimized' options
+optimized_win32          = BuildValues()    # Do NOT comment out this line
+optimized_win32.cflags   = '/O2'
+
+# Set project specific 'debug' options
+debug_win32          = BuildValues()       # Do NOT comment out this line
+debug_win32.cflags   = '/D "KIT_DEBUG"'
+
+
+#-------------------------------------------------
+# ONLY edit this section if you are have more than
+# ONE build configuration/variant 
+#-------------------------------------------------
+
+win32_build_opts = { 'user_base':base_win32, 
+                     'user_optimized':optimized_win32, 
+                     'user_debug':debug_win32
+                   }
+               
+# Add new variant option dictionary to # dictionary of 
+# build variants
+build_variants = { 'win32':win32_build_opts,
+                 }    
+
+#---------------------------------------------------
+# END EDITS/CUSTOMIZATIONS
+#===================================================
+
+
+# Select Module that contains the desired toolchain
+from nqbplib.toolchains.windows.vc12.console_exe import ToolChain
+
+# Function that instantiates an instance of the toolchain
+def create():
+    tc = ToolChain( FINAL_OUTPUT_NAME, prjdir, build_variants, 'win32' )
+    return tc 

--- a/src/Kit/Itc/_0test/_0build/windows/msvc/nqbp.py
+++ b/src/Kit/Itc/_0test/_0build/windows/msvc/nqbp.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+"""Invokes NQBP's mk.py script"""
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+	# Make sure the environment is properly set
+	NQBP_BIN = os.environ.get('NQBP_BIN')
+	if ( NQBP_BIN == None ):
+	    sys.exit( "ERROR: The environment variable NQBP_BIN is not set!" )
+	sys.path.append( NQBP_BIN )
+
+	# Find the Package & Workspace root
+	from nqbplib import utils
+	utils.set_pkg_and_wrkspace_roots(__file__)
+
+	# Call into core/common scripts
+	import mytoolchain
+	from nqbplib import mk
+	mk.build( sys.argv, mytoolchain.create() )
+

--- a/src/Kit/Itc/_0test/_0build/windows/msvc/sources.b
+++ b/src/Kit/Itc/_0test/_0build/windows/msvc/sources.b
@@ -1,0 +1,2 @@
+# share a common main
+../../main.cpp

--- a/src/Kit/Itc/_0test/async.cpp
+++ b/src/Kit/Itc/_0test/async.cpp
@@ -1,0 +1,156 @@
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+
+#include "Kit/Itc/OpenCloseSync.h"
+#include "Kit/System/_testsupport/ShutdownUnitTesting.h"
+#include "catch2/catch_test_macros.hpp"
+#include "ITestRequest.h"
+#include "AsyncClient.h"
+#include "Kit/EventQueue/Server.h"
+#include "Kit/System/Thread.h"
+#include "Kit/System/api.h"
+
+#define SECT_ "_0test"
+
+///
+using namespace Kit::Itc;
+using namespace Kit::System;
+
+////////////////////////////////////////////////////////////////////////////////
+// Anonymous namespace
+namespace {
+
+// Dummy service to test the OpenSync class
+class MockService : public OpenCloseSync, public ITestRequest
+{
+public:
+    bool    isOpened = false;
+    uint8_t byteVal  = 0;
+    MockService( Kit::EventQueue::IQueue& myEventQueue ) noexcept
+        : OpenCloseSync( myEventQueue )
+        , isOpened( false )
+    {
+    }
+
+public:
+    /// See Kit::Itc::IOpenRequest
+    void request( OpenMsg& msg ) noexcept override
+    {
+        msg.getPayload().success = true;
+        isOpened                 = true;
+        msg.returnToSender();
+    }
+
+    /// See Kit::Itc::IOpenRequest
+    void request( CloseMsg& msg ) noexcept override
+    {
+        msg.getPayload().success = true;
+        isOpened                 = false;
+        msg.returnToSender();
+    }
+
+    void request( ReadMsg& msg ) noexcept override
+    {
+
+        msg.getPayload().success = true;
+        msg.getPayload().dstData = byteVal;
+        KIT_SYSTEM_TRACE_MSG( SECT_, "REQ: Read: dstData=%u, success=%d", msg.getPayload().dstData, msg.getPayload().success );
+        msg.returnToSender();
+    }
+
+    virtual void request( WriteMsg& msg ) noexcept override
+    {
+        KIT_SYSTEM_TRACE_MSG( SECT_, "REQ: Write: srcByte=%u, success=%d", msg.getPayload().srcData, msg.getPayload().success );
+
+        msg.getPayload().success = true;
+        byteVal                  = msg.getPayload().srcData + 1;
+        msg.returnToSender();
+    }
+};
+
+
+}  // end anonymous namespace
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_CASE( "Async" )
+{
+    ShutdownUnitTesting::clearAndUseCounter();
+
+    Kit::EventQueue::Server serverEventLoop;
+    Kit::EventQueue::Server clientEventLoop;
+
+    // Create test threads
+    auto serverThread = Kit::System::Thread::create( serverEventLoop, "ServerThread" );
+    REQUIRE( serverThread != nullptr );
+    auto clientThread = Kit::System::Thread::create( clientEventLoop, "ClientThread" );
+    REQUIRE( clientThread != nullptr );
+
+    SECTION( "happy-path" )
+    {
+        MockService       uutServer( serverEventLoop );
+        ITestRequest::SAP serverSAP( uutServer, serverEventLoop );
+        AsyncClient       uutClient( clientEventLoop, serverSAP, Thread::getCurrent() );
+
+        // Open both client and server. Server MUST be opened first due to how the test is constructed
+        bool result = uutServer.open();
+        REQUIRE( result == true );
+        REQUIRE( uutServer.isOpened == true );
+        result = uutClient.open( (void*)42 );
+        REQUIRE( result == true );
+        REQUIRE( uutClient.m_opened == true );
+
+        // Wait for the test sequence to complete
+        Thread::wait();
+        Thread::wait();
+
+        REQUIRE( uutServer.byteVal == ( 42 + 1 ) );
+        uutServer.close();
+        REQUIRE( uutServer.isOpened == false );
+        REQUIRE( uutClient.m_readRspReceived == true );
+        REQUIRE( uutClient.m_writeRspReceived == true );
+        uutClient.close();
+        REQUIRE( uutClient.m_opened == false );
+    }
+
+    SECTION( "abandon" )
+    {
+        MockService       uutServer( serverEventLoop );
+        ITestRequest::SAP serverSAP( uutServer, serverEventLoop );
+        AsyncClient       uutClient( clientEventLoop, serverSAP, Thread::getCurrent(), true );
+
+        // Open both client and server. Server MUST be opened first due to hold the test is constructed
+        bool result = uutServer.open();
+        REQUIRE( result == true );
+        REQUIRE( uutServer.isOpened == true );
+        result = uutClient.open( (void*)42 );
+        REQUIRE( result == true );
+        REQUIRE( uutClient.m_opened == true );
+
+        // Wait for the test sequence to complete
+        Thread::wait();
+        Kit::System::sleep( 400 );  // Give time for the read response to arrive at client -->which it won't because it was abandoned
+        REQUIRE( uutServer.byteVal == ( 42 + 1 ) );
+
+        uutServer.close();
+        REQUIRE( uutServer.isOpened == false );
+        REQUIRE( uutClient.m_readRspReceived == false );
+        REQUIRE( uutClient.m_writeRspReceived == true );
+        uutClient.close();
+        REQUIRE( uutClient.m_opened == false );
+    }
+    // Shutdown threads
+    clientEventLoop.pleaseStop();
+    serverEventLoop.pleaseStop();
+    Kit::System::Thread::destroy( *clientThread );
+    Kit::System::Thread::destroy( *serverThread );
+
+    REQUIRE( ShutdownUnitTesting::getAndClearCounter() == 0u );
+}

--- a/src/Kit/Itc/_0test/openclose.cpp
+++ b/src/Kit/Itc/_0test/openclose.cpp
@@ -1,0 +1,121 @@
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+
+#include "Kit/Itc/OpenCloseSync.h"
+#include "Kit/System/_testsupport/ShutdownUnitTesting.h"
+#include "catch2/catch_test_macros.hpp"
+#include "Kit/Itc/OpenSync.h"
+#include "Kit/EventQueue/Server.h"
+#include "Kit/System/Thread.h"
+
+///
+using namespace Kit::Itc;
+using namespace Kit::System;
+
+////////////////////////////////////////////////////////////////////////////////
+// Anonymous namespace
+namespace {
+
+// Dummy service to test the OpenSync class
+class MockService : public OpenCloseSync
+{
+public:
+    bool  isOpened       = false;
+    bool  resultOpenMsg  = true;
+    void* argsOpenMsg    = nullptr;
+    bool  resultCloseMsg = true;
+    void* argsCloseMsg   = nullptr;
+
+    MockService( Kit::EventQueue::IQueue& myEventQueue ) noexcept
+        : OpenCloseSync( myEventQueue )
+        , isOpened( false )
+    {
+    }
+
+public:
+    /// See Kit::Itc::IOpenRequest
+    void request( OpenMsg& msg ) noexcept override
+    {
+        msg.getPayload().success = resultOpenMsg;
+        argsOpenMsg              = msg.getPayload().args;
+        isOpened                 = true;
+        msg.returnToSender();
+    }
+
+    /// See Kit::Itc::IOpenRequest
+    void request( CloseMsg& msg ) noexcept override
+    {
+        msg.getPayload().success = resultCloseMsg;
+        argsCloseMsg             = msg.getPayload().args;
+        isOpened                 = false;
+        msg.returnToSender();
+    }
+};
+
+
+}  // end anonymous namespace
+
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_CASE( "OpenClose" )
+{
+    ShutdownUnitTesting::clearAndUseCounter();
+
+    Kit::EventQueue::Server uutEventLoop;
+    MockService             uut( uutEventLoop );
+
+    // Create test thread
+    auto testThread = Kit::System::Thread::create( uutEventLoop, "TestThread" );
+    REQUIRE( testThread != nullptr );
+
+    SECTION( "happy-path" )
+    {
+        bool result = uut.open();
+        REQUIRE( result == true );
+        REQUIRE( uut.isOpened == true );
+        REQUIRE( uut.argsOpenMsg == nullptr );
+
+        result = uut.close();
+        REQUIRE( result == true );
+        REQUIRE( uut.isOpened == false );
+        REQUIRE( uut.argsCloseMsg == nullptr );
+    }
+
+    SECTION( "failed-open/close" )
+    {
+        uut.resultOpenMsg  = false;
+        uut.resultCloseMsg = false;
+        bool result        = uut.open();
+        REQUIRE( result == false );
+
+        result = uut.close();
+        REQUIRE( result == false );
+    }
+
+    SECTION( "args" )
+    {
+        bool result = uut.open( (void*)1234 );
+        REQUIRE( result == true );
+        REQUIRE( uut.isOpened == true );
+        REQUIRE( uut.argsOpenMsg == (void*)1234 );
+
+        result = uut.close( (void*)12 );
+        REQUIRE( result == true );
+        REQUIRE( uut.isOpened == false );
+        REQUIRE( uut.argsCloseMsg == (void*)12 );
+    }
+
+    // Shutdown threads
+    uutEventLoop.pleaseStop();
+    Kit::System::Thread::destroy( *testThread );
+
+    REQUIRE( ShutdownUnitTesting::getAndClearCounter() == 0u );
+}


### PR DESCRIPTION
- Ported CPL ITC abstraction - with following changes
  - Did **not** port the "Atomic API" interfaces (IME -never used/needed)
  - Introduced an `EventQueue` to resolve the issue in CPL on whether to use a Cpl::Itc::MailboxServer vs a Cpl::Dm::MailboxServer