### PR TITLE
13 add thread watchdog

### DIFF
--- a/src/Kit/System/Watchdog/Macros.h
+++ b/src/Kit/System/Watchdog/Macros.h
@@ -62,8 +62,21 @@
 #else
 
 // When watchdog is disabled, macros expand to nothing
+
+/** Disabled macro - expands to empty when USE_KIT_SYSTEM_WATCHDOG is not defined.
+    @param watcher Unused parameter when disabled
+    @param eventLoop Unused parameter when disabled
+ */
 #define KIT_WDOG_START_EVENTLOOP(watcher, eventLoop)    do { } while(0)
+
+/** Disabled macro - expands to empty when USE_KIT_SYSTEM_WATCHDOG is not defined.
+    @param watcher Unused parameter when disabled
+ */
 #define KIT_WDOG_STOP_EVENTLOOP(watcher)                do { } while(0)
+
+/** Disabled macro - expands to empty when USE_KIT_SYSTEM_WATCHDOG is not defined.
+    @param watcher Unused parameter when disabled
+ */
 #define KIT_WDOG_EVENTLOOP_MONITOR(watcher)             do { } while(0)
 
 #endif  // USE_KIT_SYSTEM_WATCHDOG

--- a/src/Kit/System/Watchdog/WatchedEventThread.h
+++ b/src/Kit/System/Watchdog/WatchedEventThread.h
@@ -78,9 +78,6 @@ protected:
 
     /** Timer expired callback - called by the TimerComposer when the health check timer expires.
         This method performs the health check and restarts the timer.
-
-        @param currentTick The current system tick when the timer expired
-        @param currentTime The current elapsed time when the timer expired
      */
     void expired() noexcept;
 


### PR DESCRIPTION
Added support for watchdog. This module provides software watchdog support for both raw threads and event-loop threads. 

Also added watchdog specific test file to capture core watchdog functionality for raw and event based threads.
