### PR TITLE
98 refactor Dm::Persistent::Record to use composition for its SW timer

### DIFF
--- a/src/Kit/Dm/Persistence/Record.cpp
+++ b/src/Kit/Dm/Persistence/Record.cpp
@@ -47,7 +47,7 @@ bool Record::start( Kit::EventQueue::IQueue& myEventQueue ) noexcept
         // Housekeeping
         m_started         = true;
         m_myEventQueuePtr = &myEventQueue;
-        setTimingSource( myEventQueue );
+        m_timer.setTimingSource( myEventQueue );
 
         // Load the record's data from persistent storage
         bool subscribeForChanges = true;
@@ -99,7 +99,7 @@ void Record::stop() noexcept
     if ( m_started )
     {
         m_started = false;
-        Timer::stop();
+        m_timer.stop();
 
         // Cancel subscriptions
         for ( unsigned i = 0; i < m_numItems; i++ )
@@ -239,7 +239,7 @@ void Record::dataChanged( Kit::Dm::IModelPoint& point, Kit::Dm::IObserver& obser
     {
         // If the timer is not running -->then this is the 'first' change notification
         uint32_t now = Kit::System::ElapsedTime::milliseconds();
-        if ( !Timer::isRunning() )
+        if ( !m_timer.isRunning() )
         {
             m_timerMarker = now;
         }
@@ -247,19 +247,19 @@ void Record::dataChanged( Kit::Dm::IModelPoint& point, Kit::Dm::IObserver& obser
         // Update NVRAM if the maximum delay time has expired
         if ( Kit::System::ElapsedTime::expiredMilliseconds( m_timerMarker, m_maxDelayMs, now ) )
         {
-            Timer::stop();
+            m_timer.stop();
             updateNVRAM();
         }
 
         // Start my software timer to delay the update to NVRAM
         else
         {
-            Timer::start( m_delayMs );
+            m_timer.start( m_delayMs );
         }
     }
 }
 
-void Record::expired( void ) noexcept
+void Record::timerExpired( void ) noexcept
 {
     updateNVRAM();
 }

--- a/src/Kit/Dm/Persistence/Record.h
+++ b/src/Kit/Dm/Persistence/Record.h
@@ -40,8 +40,7 @@ namespace Persistence {
  */
 class Record : public Kit::Persistence::Record::IRecord,
                public Kit::Persistence::Record::IPayload,
-               public Kit::Dm::Persistence::IManageRequest,
-               public Kit::System::Timer
+               public Kit::Dm::Persistence::IManageRequest
 {
 public:
     /** This data structure associates a Data Model subscriber instance with a
@@ -79,7 +78,7 @@ public:
             uint8_t                           schemaMinorIndex,
             uint32_t                          writeDelayMs    = 0,
             uint32_t                          maxWriteDelayMs = 0 ) noexcept
-        : Kit::System::Timer( nullptr )
+        : m_timer( *this, &Record::timerExpired )
         , m_myEventQueuePtr( nullptr )
         , m_items( itemList )
         , m_chunkHandler( chunkHandler )
@@ -102,9 +101,6 @@ public:
     }
 
 public:
-    /// Re-expose Timer overload(s) to avoid hiding warnings with stricter compilers.
-    using Kit::System::Timer::start;
-
     /// See Kit::Persistence::Record::IRecord
     bool start( Kit::EventQueue::IQueue& myEventQueue ) noexcept override;
 
@@ -183,7 +179,7 @@ protected:
     virtual void hookProcessPostRecordLoaded() noexcept {};
 
     /// Settling timer expired callback
-    void expired( void ) noexcept override;
+    virtual void timerExpired( void ) noexcept;
 
 
 protected:
@@ -194,6 +190,9 @@ protected:
     virtual void updateNVRAM() noexcept;
 
 protected:
+    /// Software Timer
+    Kit::System::TimerComposer<Record> m_timer;
+
     /// The Event Queue that I am running in (used for my timer)
     Kit::EventQueue::IQueue* m_myEventQueuePtr;
 


### PR DESCRIPTION
- Use of composition allows the a DM Record to be in list - as before it could only be in the SW timer list because of how KIT containers work