### PR TITLE
Fix link to KIT's coding standards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ being merged to the `main` branch. All PRs must adhere the project's [Software D
 
 
 ## Coding style
-Please ensure that your code complies to the KIT's [coding standard](https://github.com/integerfox/kit/wiki/Coding-Standards).
+Please ensure that your code complies to the KIT's [coding standard](https://github.com/integerfox/kit.core/wiki/Coding-Standards).
 
 
 ## Licensing


### PR DESCRIPTION
Corrected the link to the KIT's coding standards in the CONTRIBUTING.md file.