### PR TITLE
103 add frame decoders and encoders to the text namespace

### DIFF
--- a/src/Kit/Framing/DecoderReader.cpp
+++ b/src/Kit/Framing/DecoderReader.cpp
@@ -29,6 +29,11 @@ uint8_t DecoderReader::decodeEscapedByte( uint8_t escapedByte ) noexcept
     return escapedByte;
 }
 
+bool DecoderReader::isLegalByte( uint8_t byte ) noexcept
+{
+    return true;
+}
+
 ///////////////////
 bool DecoderReader::scan( Kit::Type::SSize_T  maxSizeOfFrameBuffer,
                           uint8_t*            frameBuffer,
@@ -73,7 +78,7 @@ bool DecoderReader::scan( Kit::Type::SSize_T  maxSizeOfFrameBuffer,
     // Get more input data once my local buffer/cache is empty
     if ( !m_dataLen )
     {
-        if ( !read( m_buffer, m_bufSize, m_dataLen ) )
+        if ( !m_src.read( m_buffer, m_bufSize, m_dataLen ) )
         {
             // Error reading data -->exit scan
             m_dataLen = 0;  // Reset my internal count so I start 'over' on the next call (if there is one)
@@ -92,7 +97,7 @@ bool DecoderReader::scan( Kit::Type::SSize_T  maxSizeOfFrameBuffer,
         // OUTSIDE of a frame
         if ( !m_inFrame )
         {
-            if ( isStartOfFrame( *m_dataPtr) )
+            if ( isStartOfFrame( *m_dataPtr ) )
             {
                 m_inFrame   = true;
                 m_escaping  = false;
@@ -105,7 +110,7 @@ bool DecoderReader::scan( Kit::Type::SSize_T  maxSizeOfFrameBuffer,
         else
         {
             // Trap illegal characters
-            if ( !isLegalByte( *m_dataPtr) )
+            if ( !isLegalByte( *m_dataPtr ) )
             {
                 m_inFrame = false;
             }
@@ -114,7 +119,7 @@ bool DecoderReader::scan( Kit::Type::SSize_T  maxSizeOfFrameBuffer,
             else if ( !m_escaping )
             {
                 // EOF Character
-                if ( isEndOfFrame( *m_dataPtr) )
+                if ( isEndOfFrame( *m_dataPtr ) )
                 {
                     // EXIT routine with a success return code
                     m_dataPtr++;  // Explicitly consume the EOF character (since we are brute force exiting the loop)
@@ -123,6 +128,13 @@ bool DecoderReader::scan( Kit::Type::SSize_T  maxSizeOfFrameBuffer,
                     isEof     = true;
                     initializeScan();  // Reset my internal frame state to be ready for the next frame
                     return true;
+                }
+
+                // SOF Character -->need to reset the frame
+                else if ( isStartOfFrame( *m_dataPtr ) )
+                {
+                    m_frameSize = 0;
+                    m_framePtr  = frameBuffer;
                 }
 
                 // Regular character
@@ -186,11 +198,11 @@ bool DecoderReader::oobRead( uint8_t*            buffer,
         return false;
     }
 
-    // No cached data 
+    // No cached data
     if ( !m_dataLen )
     {
         // Read data from the input source into the local cache
-        if ( !read( m_buffer, m_bufSize, m_dataLen ) )
+        if ( !m_src.read( m_buffer, m_bufSize, m_dataLen ) )
         {
             return false;
         }
@@ -211,7 +223,8 @@ bool DecoderReader::oobRead( uint8_t*            buffer,
     m_dataLen -= numBytes;
     m_dataPtr += numBytes;
     bytesRead  = numBytes;
-    return true;}
+    return true;
+}
 
 
 }  // end namespace

--- a/src/Kit/Framing/DecoderReader.cpp
+++ b/src/Kit/Framing/DecoderReader.cpp
@@ -92,7 +92,7 @@ bool DecoderReader::scan( Kit::Type::SSize_T  maxSizeOfFrameBuffer,
         // OUTSIDE of a frame
         if ( !m_inFrame )
         {
-            if ( isStartOfFrame() )
+            if ( isStartOfFrame( *m_dataPtr) )
             {
                 m_inFrame   = true;
                 m_escaping  = false;
@@ -105,7 +105,7 @@ bool DecoderReader::scan( Kit::Type::SSize_T  maxSizeOfFrameBuffer,
         else
         {
             // Trap illegal characters
-            if ( !isLegalByte() )
+            if ( !isLegalByte( *m_dataPtr) )
             {
                 m_inFrame = false;
             }
@@ -114,7 +114,7 @@ bool DecoderReader::scan( Kit::Type::SSize_T  maxSizeOfFrameBuffer,
             else if ( !m_escaping )
             {
                 // EOF Character
-                if ( isEndOfFrame() )
+                if ( isEndOfFrame( *m_dataPtr) )
                 {
                     // EXIT routine with a success return code
                     m_dataPtr++;  // Explicitly consume the EOF character (since we are brute force exiting the loop)
@@ -126,7 +126,7 @@ bool DecoderReader::scan( Kit::Type::SSize_T  maxSizeOfFrameBuffer,
                 }
 
                 // Regular character
-                else if ( !isEscapeByte() )
+                else if ( !isEscapeByte( *m_dataPtr ) )
                 {
                     // Store incoming character into the Client's buffer
                     if ( m_frameSize < maxSizeOfFrameBuffer )

--- a/src/Kit/Framing/DecoderReader.cpp
+++ b/src/Kit/Framing/DecoderReader.cpp
@@ -1,0 +1,219 @@
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "DecoderReader.h"
+#include <string.h>
+
+//------------------------------------------------------------------------------
+namespace Kit {
+namespace Framing {
+
+///////////////////
+void DecoderReader::initializeScan() noexcept
+{
+    m_framePtr  = nullptr;
+    m_frameSize = 0;
+    m_inFrame   = false;
+    m_escaping  = false;
+}
+
+uint8_t DecoderReader::decodeEscapedByte( uint8_t escapedByte )
+{
+    return escapedByte;
+}
+
+///////////////////
+bool DecoderReader::scan( Kit::Type::SSize_T  maxSizeOfFrameBuffer,
+                          uint8_t*            frameBuffer,
+                          Kit::Type::SSize_T& frameSize ) noexcept
+{
+    // Housekeeping
+    initializeScan();
+
+    // Zero out size of the found frame
+    frameSize = 0;
+
+    // Error case: Treat a null frame buffer as an IO failure case
+    if ( !frameBuffer )
+    {
+        return false;
+    }
+
+    // Scan till a frame is found
+    for ( ;; )
+    {
+        // Read N characters at time
+        bool isEof;
+        if ( !scan( maxSizeOfFrameBuffer, frameBuffer, frameSize, isEof ) )
+        {
+            return false;  // Read/IO error occurred
+        }
+        else if ( isEof )
+        {
+            return true;  // Frame Found!
+        }
+    }
+}
+
+bool DecoderReader::scan( Kit::Type::SSize_T  maxSizeOfFrameBuffer,
+                          uint8_t*            frameBuffer,
+                          Kit::Type::SSize_T& frameSize,
+                          bool&               isEof ) noexcept
+{
+    // Default to in-progress
+    isEof = false;
+
+    // Get more input data once my local buffer/cache is empty
+    if ( !m_dataLen )
+    {
+        if ( !read( m_buffer, m_bufSize, m_dataLen ) )
+        {
+            // Error reading data -->exit scan
+            m_dataLen = 0;  // Reset my internal count so I start 'over' on the next call (if there is one)
+            frameSize = m_frameSize;
+            initializeScan();
+            return false;
+        }
+
+        // Reset my data pointer
+        m_dataPtr = m_buffer;
+    }
+
+    // Process my input buffer one character at a time
+    for ( ; m_dataLen; m_dataLen--, m_dataPtr++ )
+    {
+        // OUTSIDE of a frame
+        if ( !m_inFrame )
+        {
+            if ( isStartOfFrame() )
+            {
+                m_inFrame   = true;
+                m_escaping  = false;
+                m_frameSize = 0;
+                m_framePtr  = frameBuffer;
+            }
+        }
+
+        // INSIDE a frame
+        else
+        {
+            // Trap illegal characters
+            if ( !isLegalByte() )
+            {
+                m_inFrame = false;
+            }
+
+            // No escape sequence in progress
+            else if ( !m_escaping )
+            {
+                // EOF Character
+                if ( isEndOfFrame() )
+                {
+                    // EXIT routine with a success return code
+                    m_dataPtr++;  // Explicitly consume the EOF character (since we are brute force exiting the loop)
+                    m_dataLen--;
+                    frameSize = m_frameSize;
+                    isEof     = true;
+                    initializeScan();  // Reset my internal frame state to be ready for the next frame
+                    return true;
+                }
+
+                // Regular character
+                else if ( !isEscapeByte() )
+                {
+                    // Store incoming character into the Client's buffer
+                    if ( m_frameSize < maxSizeOfFrameBuffer )
+                    {
+                        *m_framePtr++ = *m_dataPtr;
+                        m_frameSize++;
+                    }
+
+                    // Exceeded the Client's buffer space -->internal error -->reset my Frame state
+                    else
+                    {
+                        initializeScan();
+                    }
+                }
+
+                // Start escape sequence
+                else
+                {
+                    m_escaping = true;
+                }
+            }
+
+
+            // Escape Sequence
+            else
+            {
+                // Store the escaped character into the Client's buffer
+                if ( m_frameSize < maxSizeOfFrameBuffer )
+                {
+                    m_escaping    = false;
+                    *m_framePtr++ = decodeEscapedByte( *m_dataPtr );
+                    m_frameSize++;
+                }
+
+                // Exceeded the Client's buffer space -->internal error -->reset my Frame state
+                else
+                {
+                    initializeScan();
+                }
+            }
+        }
+    }
+
+    // If I get here there was no IO error - but still no End-of-Frame
+    frameSize = m_frameSize;
+    return true;
+}
+
+
+bool DecoderReader::oobRead( uint8_t*            buffer,
+                             Kit::Type::SSize_T  numBytes,
+                             Kit::Type::SSize_T& bytesRead ) noexcept
+{
+    // FAIL if processing a frame
+    if ( m_inFrame )
+    {
+        return false;
+    }
+
+    // No cached data 
+    if ( !m_dataLen )
+    {
+        // Read data from the input source into the local cache
+        if ( !read( m_buffer, m_bufSize, m_dataLen ) )
+        {
+            return false;
+        }
+        m_dataPtr = m_buffer;
+    }
+
+    // More data requested than what is cached
+    if ( numBytes > m_dataLen )
+    {
+        bytesRead = m_dataLen;
+        m_dataLen = 0;
+        memcpy( buffer, m_dataPtr, bytesRead );
+        return true;
+    }
+
+    // Consume part of the cached data
+    memcpy( buffer, m_dataPtr, numBytes );
+    m_dataLen -= numBytes;
+    m_dataPtr += numBytes;
+    bytesRead  = numBytes;
+    return true;}
+
+
+}  // end namespace
+}
+//------------------------------------------------------------------------------

--- a/src/Kit/Framing/DecoderReader.cpp
+++ b/src/Kit/Framing/DecoderReader.cpp
@@ -24,7 +24,7 @@ void DecoderReader::initializeScan() noexcept
     m_escaping  = false;
 }
 
-uint8_t DecoderReader::decodeEscapedByte( uint8_t escapedByte )
+uint8_t DecoderReader::decodeEscapedByte( uint8_t escapedByte ) noexcept
 {
     return escapedByte;
 }

--- a/src/Kit/Framing/DecoderReader.h
+++ b/src/Kit/Framing/DecoderReader.h
@@ -41,6 +41,7 @@ protected:
     , m_inFrame( false )
     , m_escaping( false )
     {
+        initializeScan();
     }
 
 public:
@@ -62,16 +63,16 @@ public:
 
 protected:
     /// Returns true if at start-of-frame
-    virtual bool isStartOfFrame() noexcept = 0;
+    virtual bool isStartOfFrame( uint8_t byte ) noexcept = 0;
 
     /// Returns true if at end-of-frame
-    virtual bool isEndOfFrame() noexcept = 0;
+    virtual bool isEndOfFrame( uint8_t byte ) noexcept = 0;
 
     /// Returns true if the start of the start of a escape sequence has been detected
-    virtual bool isEscapeByte() noexcept = 0;
+    virtual bool isEscapeByte( uint8_t byte ) noexcept = 0;
 
     /// Returns true if the current byte is a legal/valid within a frame
-    virtual bool isLegalByte() noexcept = 0;
+    virtual bool isLegalByte( uint8_t byte ) noexcept = 0;
 
     /** Attempts to read the specified number of bytes from the "input source"
         into the supplied buffer.  The actual number of bytes read is returned via

--- a/src/Kit/Framing/DecoderReader.h
+++ b/src/Kit/Framing/DecoderReader.h
@@ -11,6 +11,7 @@
 /** @file */
 
 #include "Kit/Framing/IDecoder.h"
+#include "Kit/Framing/ISource.h"
 
 
 ///
@@ -18,28 +19,28 @@ namespace Kit {
 ///
 namespace Framing {
 
-/** This partially concrete class implements the basic scanning/reading logic
-    for a Decoder
+/** This concrete class implements the basic scanning/reading logic
+    for a Decoder. The provided ISource instance determines the "input source".
  */
 class DecoderReader : public IDecoder
 {
-protected:
+public:
     /** Constructor. The size of the workBuffer determines how big of
         'chunks' data is read from the "input source", i.e. it is a working
         buffer and does NOT have to be the size of the maximum possible input
         frame.
      */
-    DecoderReader( uint8_t* workBuffer, Kit::Type::SSize_T sizeOfWorkBuffer )
-    : m_dataPtr( nullptr )
-    , m_buffer( workBuffer )
-    , m_framePtr( nullptr )
-    , m_dataLen( 0 )
-    , m_frameSize( 0 )
-    , m_bufSize( sizeOfWorkBuffer )
-    , m_inFrame( false )
-    , m_escaping( false )
+    DecoderReader( ISource& source, uint8_t* workBuffer, Kit::Type::SSize_T sizeOfWorkBuffer )
+        : m_src( source )
+        , m_dataPtr( nullptr )
+        , m_buffer( workBuffer )
+        , m_framePtr( nullptr )
+        , m_dataLen( 0 )
+        , m_frameSize( 0 )
+        , m_bufSize( sizeOfWorkBuffer )
+        , m_inFrame( false )
+        , m_escaping( false )
     {
-        initializeScan();
     }
 
 public:
@@ -69,17 +70,11 @@ protected:
     /// Returns true if the start of the start of a escape sequence has been detected
     virtual bool isEscapeByte( uint8_t byte ) noexcept = 0;
 
-    /// Returns true if the current byte is a legal/valid within a frame
-    virtual bool isLegalByte( uint8_t byte ) noexcept = 0;
+    /** Returns true if the current byte is a legal/valid within a frame
+        The default implementation simply returns true for all bytes.
+    */
+    virtual bool isLegalByte( uint8_t byte ) noexcept;
 
-    /** Attempts to read the specified number of bytes from the "input source"
-        into the supplied buffer.  The actual number of bytes read is returned via
-        'bytesRead'. Returns true if successful, or false if End-of-Input
-        was encountered.
-     */
-    virtual bool read( void*               dstBuffer,
-                       Kit::Type::SSize_T  numBytes,
-                       Kit::Type::SSize_T& bytesRead ) noexcept = 0;
 
     /** Returns the un-encoded value for the specified escaped byte.  The
         default implementation simply returns 'escapedByte'
@@ -91,6 +86,9 @@ protected:
     virtual void initializeScan() noexcept;
 
 protected:
+    /// Reference to the input source
+    ISource& m_src;
+
     /// Pointer to the next unprocessed character in my raw input buffer
     uint8_t* m_dataPtr;
 

--- a/src/Kit/Framing/DecoderReader.h
+++ b/src/Kit/Framing/DecoderReader.h
@@ -26,18 +26,18 @@ namespace Framing {
 class DecoderReader : public IDecoder
 {
 protected:
-    /** Constructor. The size of the rawInputBuffer determines how big of
+    /** Constructor. The size of the workBuffer determines how big of
         'chunks' data is read from the "input source", i.e. it is a working
         buffer and does NOT have to be the size of the maximum possible input
         frame.
      */
-    DecoderReader( uint8_t* rawInputBuffer, Kit::Type::SSize_T sizeOfRawInputBuffer )
+    DecoderReader( uint8_t* workBuffer, Kit::Type::SSize_T sizeOfWorkBuffer )
     : m_dataPtr( nullptr )
-    , m_buffer( rawInputBuffer )
+    , m_buffer( workBuffer )
     , m_framePtr( nullptr )
     , m_dataLen( 0 )
     , m_frameSize( 0 )
-    , m_bufSize( sizeOfRawInputBuffer )
+    , m_bufSize( sizeOfWorkBuffer )
     , m_inFrame( false )
     , m_escaping( false )
     {
@@ -56,7 +56,7 @@ public:
                        bool&               isEof ) noexcept override;
 
     /// See Kit::Framing::IDecoder
-    virtual bool oobRead( uint8_t*            buffer,
+    virtual bool oobRead( uint8_t*            dstBuffer,
                           Kit::Type::SSize_T  numBytes,
                           Kit::Type::SSize_T& bytesRead ) noexcept override;
 
@@ -78,7 +78,7 @@ protected:
         'bytesRead'. Returns true if successful, or false if End-of-Input
         was encountered.
      */
-    virtual bool read( void*               buffer,
+    virtual bool read( void*               dstBuffer,
                        Kit::Type::SSize_T  numBytes,
                        Kit::Type::SSize_T& bytesRead ) = 0;
 
@@ -87,6 +87,7 @@ protected:
      */
     virtual uint8_t decodeEscapedByte( uint8_t escapedByte );
 
+protected:
     /// Helper method to initialize frame processing
     virtual void initializeScan() noexcept;
 
@@ -94,19 +95,19 @@ protected:
     /// Pointer to the next unprocessed character in my raw input buffer
     uint8_t* m_dataPtr;
 
-    /// Raw input buffer for reading characters in 'chunks' from my Input source (i.e. minimize the calls to read())
+    /// Work buffer for reading characters in 'chunks' from my Input source (i.e. minimize the calls to read())
     uint8_t* m_buffer;
 
     /// Pointer to the next decoded frame character
     uint8_t* m_framePtr;
 
-    /// Current number of characters remaining in my raw input buffer
+    /// Current number of characters remaining in my work buffer
     Kit::Type::SSize_T m_dataLen;
 
     /// Number of bytes current decoded for the frame
     Kit::Type::SSize_T m_frameSize;
 
-    /// Size of my raw input buffer
+    /// Size of my work buffer
     Kit::Type::SSize_T m_bufSize;
 
     /// Flag: I am currently in a Frame

--- a/src/Kit/Framing/DecoderReader.h
+++ b/src/Kit/Framing/DecoderReader.h
@@ -1,0 +1,122 @@
+#ifndef KIT_FRAMING_DECODER_READER_H_
+#define KIT_FRAMING_DECODER_READER_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Framing/IDecoder.h"
+#include "Kit/Type/SSize.h"
+#include <cstdint>
+
+
+///
+namespace Kit {
+///
+namespace Framing {
+
+/** This partially concrete class implements the basic scanning/reading logic
+    for a Decoder
+ */
+class DecoderReader : public IDecoder
+{
+protected:
+    /** Constructor. The size of the rawInputBuffer determines how big of
+        'chunks' data is read from the "input source", i.e. it is a working
+        buffer and does NOT have to be the size of the maximum possible input
+        frame.
+     */
+    DecoderReader( uint8_t* rawInputBuffer, Kit::Type::SSize_T sizeOfRawInputBuffer )
+    : m_dataPtr( nullptr )
+    , m_buffer( rawInputBuffer )
+    , m_framePtr( nullptr )
+    , m_dataLen( 0 )
+    , m_frameSize( 0 )
+    , m_bufSize( sizeOfRawInputBuffer )
+    , m_inFrame( false )
+    , m_escaping( false )
+    {
+    }
+
+public:
+    /// See Kit::Framing::IDecoder
+    virtual bool scan( Kit::Type::SSize_T  maxSizeOfFrameBuffer,
+                       uint8_t*            frameBuffer,
+                       Kit::Type::SSize_T& frameSize ) noexcept override;
+
+    /// See Kit::Framing::IDecoder
+    virtual bool scan( Kit::Type::SSize_T  maxSizeOfFrameBuffer,
+                       uint8_t*            frameBuffer,
+                       Kit::Type::SSize_T& frameSize,
+                       bool&               isEof ) noexcept override;
+
+    /// See Kit::Framing::IDecoder
+    virtual bool oobRead( uint8_t*            buffer,
+                          Kit::Type::SSize_T  numBytes,
+                          Kit::Type::SSize_T& bytesRead ) noexcept override;
+
+protected:
+    /// Returns true if at start-of-frame
+    virtual bool isStartOfFrame() noexcept = 0;
+
+    /// Returns true if at end-of-frame
+    virtual bool isEndOfFrame() noexcept = 0;
+
+    /// Returns true if the start of the start of a escape sequence has been detected
+    virtual bool isEscapeByte() noexcept = 0;
+
+    /// Returns true if the current byte is a legal/valid within a frame
+    virtual bool isLegalByte() noexcept = 0;
+
+    /** Attempts to read the specified number of bytes from the "input source"
+        into the supplied buffer.  The actual number of bytes read is returned via
+        'bytesRead'. Returns true if successful, or false if End-of-Input
+        was encountered.
+     */
+    virtual bool read( void*               buffer,
+                       Kit::Type::SSize_T  numBytes,
+                       Kit::Type::SSize_T& bytesRead ) = 0;
+
+    /** Returns the un-encoded value for the specified escaped byte.  The
+        default implementation simply returns 'escapedByte'
+     */
+    virtual uint8_t decodeEscapedByte( uint8_t escapedByte );
+
+    /// Helper method to initialize frame processing
+    virtual void initializeScan() noexcept;
+
+protected:
+    /// Pointer to the next unprocessed character in my raw input buffer
+    uint8_t* m_dataPtr;
+
+    /// Raw input buffer for reading characters in 'chunks' from my Input source (i.e. minimize the calls to read())
+    uint8_t* m_buffer;
+
+    /// Pointer to the next decoded frame character
+    uint8_t* m_framePtr;
+
+    /// Current number of characters remaining in my raw input buffer
+    Kit::Type::SSize_T m_dataLen;
+
+    /// Number of bytes current decoded for the frame
+    Kit::Type::SSize_T m_frameSize;
+
+    /// Size of my raw input buffer
+    Kit::Type::SSize_T m_bufSize;
+
+    /// Flag: I am currently in a Frame
+    bool m_inFrame;
+
+    /// Flag: the next character is an escape character
+    bool m_escaping;
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Framing/DecoderReader.h
+++ b/src/Kit/Framing/DecoderReader.h
@@ -11,8 +11,6 @@
 /** @file */
 
 #include "Kit/Framing/IDecoder.h"
-#include "Kit/Type/SSize.h"
-#include <cstdint>
 
 
 ///
@@ -81,12 +79,12 @@ protected:
      */
     virtual bool read( void*               dstBuffer,
                        Kit::Type::SSize_T  numBytes,
-                       Kit::Type::SSize_T& bytesRead ) = 0;
+                       Kit::Type::SSize_T& bytesRead ) noexcept = 0;
 
     /** Returns the un-encoded value for the specified escaped byte.  The
         default implementation simply returns 'escapedByte'
      */
-    virtual uint8_t decodeEscapedByte( uint8_t escapedByte );
+    virtual uint8_t decodeEscapedByte( uint8_t escapedByte ) noexcept;
 
 protected:
     /// Helper method to initialize frame processing

--- a/src/Kit/Framing/EncoderWriter.cpp
+++ b/src/Kit/Framing/EncoderWriter.cpp
@@ -1,0 +1,112 @@
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "EncoderWriter.h"
+
+//------------------------------------------------------------------------------
+namespace Kit {
+namespace Framing {
+
+/////////////
+bool EncoderWriter::startFrame( void ) noexcept
+{
+    // End the current frame before starting a new one
+    if ( m_inFrame )
+    {
+        if ( !endFrame() )
+        {
+            return false;  // Failed to end the current frame
+        }
+    }
+
+    if ( !startOutput() )
+    {
+        return false;  // Failed to start the new frame
+    }
+
+    // NOT skipping the SOF byte
+    if ( !m_skipSendingSof )
+    {
+        if ( !appendOutput( m_sof ) )
+        {
+            return false;  // Failed to output the SOF byte
+        }
+    }
+    m_inFrame = true;
+    return true;
+}
+
+bool EncoderWriter::output( const void* srcBuffer, Kit::Type::SSize_T numBytes ) noexcept
+{
+    if ( !m_inFrame )
+    {
+        return false;  // Frame has not been started
+    }
+
+    const uint8_t* srcBytePtr = static_cast<const uint8_t*>( srcBuffer );
+    for ( Kit::Type::SSize_T i = 0; i < numBytes; ++i )
+    {
+        uint8_t srcByte = *srcBytePtr++;
+
+        // Escape the byte if it is a special character
+        if ( srcByte == m_sof || srcByte == m_eof || srcByte == m_esc )
+        {
+            if ( !appendOutput( m_esc ) )
+            {
+                m_inFrame = false;
+                return false;  // Failed to output the escape character
+            }
+            srcByte = encodeEscapedByte( srcByte );
+        }
+
+        // Write the next byte
+        if ( !appendOutput( srcByte ) )
+        {
+            m_inFrame = false;
+            return false;  // Failed to output the byte
+        }
+    }
+
+    return true;
+}
+
+bool EncoderWriter::endFrame( void ) noexcept
+{
+    // Frame has not been started
+    if ( !m_inFrame )
+    {
+        return false;
+    }
+
+    // Success or Error - the frame sequence is ended
+    m_inFrame = false;
+
+    // Output the End-of-Frame character
+    if ( !appendOutput( m_eof ) )
+    {
+        return false;  // Failed to output the EOF byte
+    }
+
+    if ( !endOutput() )
+    {
+        return false;  // Failed to end the frame
+    }
+
+    return true;
+}
+
+uint8_t EncoderWriter::encodeEscapedByte( uint8_t byteToBeEscaped ) noexcept
+{
+    return byteToBeEscaped;
+}
+
+}  // end namespace
+}
+//------------------------------------------------------------------------------

--- a/src/Kit/Framing/EncoderWriter.cpp
+++ b/src/Kit/Framing/EncoderWriter.cpp
@@ -26,7 +26,7 @@ bool EncoderWriter::startFrame( void ) noexcept
         }
     }
 
-    if ( !startOutput() )
+    if ( !m_dst.startOutput() )
     {
         return false;  // Failed to start the new frame
     }
@@ -34,7 +34,7 @@ bool EncoderWriter::startFrame( void ) noexcept
     // NOT skipping the SOF byte
     if ( !m_skipSendingSof )
     {
-        if ( !appendOutput( m_sof ) )
+        if ( !m_dst.appendOutput( m_sof ) )
         {
             return false;  // Failed to output the SOF byte
         }
@@ -45,9 +45,9 @@ bool EncoderWriter::startFrame( void ) noexcept
 
 bool EncoderWriter::output( const void* srcBuffer, Kit::Type::SSize_T numBytes ) noexcept
 {
-    if ( !m_inFrame )
+    if ( !m_inFrame || srcBuffer == nullptr || numBytes < 0 )
     {
-        return false;  // Frame has not been started
+        return false;  // Frame has not been started or source buffer is null
     }
 
     const uint8_t* srcBytePtr = static_cast<const uint8_t*>( srcBuffer );
@@ -58,7 +58,7 @@ bool EncoderWriter::output( const void* srcBuffer, Kit::Type::SSize_T numBytes )
         // Escape the byte if it is a special character
         if ( srcByte == m_sof || srcByte == m_eof || srcByte == m_esc )
         {
-            if ( !appendOutput( m_esc ) )
+            if ( !m_dst.appendOutput( m_esc ) )
             {
                 m_inFrame = false;
                 return false;  // Failed to output the escape character
@@ -67,7 +67,7 @@ bool EncoderWriter::output( const void* srcBuffer, Kit::Type::SSize_T numBytes )
         }
 
         // Write the next byte
-        if ( !appendOutput( srcByte ) )
+        if ( !m_dst.appendOutput( srcByte ) )
         {
             m_inFrame = false;
             return false;  // Failed to output the byte
@@ -89,12 +89,12 @@ bool EncoderWriter::endFrame( void ) noexcept
     m_inFrame = false;
 
     // Output the End-of-Frame character
-    if ( !appendOutput( m_eof ) )
+    if ( !m_dst.appendOutput( m_eof ) )
     {
         return false;  // Failed to output the EOF byte
     }
 
-    if ( !endOutput() )
+    if ( !m_dst.endOutput() )
     {
         return false;  // Failed to end the frame
     }

--- a/src/Kit/Framing/EncoderWriter.h
+++ b/src/Kit/Framing/EncoderWriter.h
@@ -26,10 +26,10 @@ namespace Framing {
 class EncoderWriter : public IEncoder
 {
 public:
-    /** Constructor. The size of the workBuffer determines how big of
-        'chunks' data is read from the "input source", i.e. it is a working
-        buffer and does NOT have to be the size of the maximum possible input
-        frame.
+    /** Constructor. When 'skipSendingSof' is set to true, the start-of-frame
+        character will NOT be sent when startFrame() is called. This should ONLY
+        be set to true when the framing protocol supports multiple SOF characters. 
+        See LineDecoder as example of such a protocol.
      */
     EncoderWriter( IDestination& destination,
                    uint8_t       startOfFrame,
@@ -80,10 +80,7 @@ protected:
     /// Flag: I am currently in a Frame
     bool m_inFrame;
 
-    /** Flag: Skip sending Start-of-Frame character. This flag should ONLY be
-        set when the child class's framing protocol supports multiple SOF characters.
-        See TBD as example of such a protocol.
-     */
+    /// Flag: Skip sending Start-of-Frame character
     bool m_skipSendingSof;
 };
 

--- a/src/Kit/Framing/EncoderWriter.h
+++ b/src/Kit/Framing/EncoderWriter.h
@@ -11,6 +11,7 @@
 /** @file */
 
 #include "Kit/Framing/IEncoder.h"
+#include "Kit/Framing/IDestination.h"
 #include "Kit/System/Assert.h"
 
 ///
@@ -18,22 +19,28 @@ namespace Kit {
 ///
 namespace Framing {
 
-/** This partially concrete class implements the basic framing/output logic
-    for an Encoder.  A child class is required to provide the "output
+/** This concrete class implements the basic framing/output logic
+    for an Encoder.  The provided IDestination instances determines the "output
     destination"
  */
 class EncoderWriter : public IEncoder
 {
-protected:
+public:
     /** Constructor. The size of the workBuffer determines how big of
         'chunks' data is read from the "input source", i.e. it is a working
         buffer and does NOT have to be the size of the maximum possible input
         frame.
      */
-    EncoderWriter( uint8_t startOfFrame, uint8_t endOfFrame, uint8_t escapeByte, bool skipSendingSof = false )
-        : m_sof( startOfFrame )
+    EncoderWriter( IDestination& destination,
+                   uint8_t       startOfFrame,
+                   uint8_t       endOfFrame,
+                   uint8_t       escapeByte,
+                   bool          skipSendingSof = false )
+        : m_dst( destination )
+        , m_sof( startOfFrame )
         , m_eof( endOfFrame )
         , m_esc( escapeByte )
+        , m_inFrame( false )
         , m_skipSendingSof( skipSendingSof )
     {
         KIT_SYSTEM_ASSERT( m_sof != m_eof );
@@ -52,31 +59,15 @@ public:
     bool endFrame( void ) noexcept override;
 
 protected:
-    /** Used to initialize the "frame output sequence". Returns true if
-        successful; else false is returned.
-    */
-    virtual bool startOutput() noexcept = 0;
-
-    /** Outputs a new/next byte to the destination.
-        Returns true if successful; else false is returned.
-    */
-    virtual bool appendOutput( uint8_t srcByte ) noexcept = 0;
-
-    /** Used to finalize the "frame output sequence". Returns true if
-        successful; else false is returned.
-
-        NOTE: There is NO guarantee that endOutput() will always be called
-              before starting a new frame.  What is guaranteed is that startOutput()
-              will be called with each new attempted frame output sequence.
-    */
-    virtual bool endOutput() noexcept = 0;
-
     /** Returns the encoded/escaped value for the specified special character.
         The default implementation simply returns 'byteToBeEscaped'
      */
     virtual uint8_t encodeEscapedByte( uint8_t byteToBeEscaped ) noexcept;
 
 protected:
+    /// Reference to the output destination
+    IDestination& m_dst;
+
     /// Start-of-Frame character
     uint8_t m_sof;
 

--- a/src/Kit/Framing/EncoderWriter.h
+++ b/src/Kit/Framing/EncoderWriter.h
@@ -1,0 +1,102 @@
+#ifndef KIT_FRAMING_ENCODER_WRITER_H_
+#define KIT_FRAMING_ENCODER_WRITER_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Framing/IEncoder.h"
+#include "Kit/System/Assert.h"
+
+///
+namespace Kit {
+///
+namespace Framing {
+
+/** This partially concrete class implements the basic framing/output logic
+    for an Encoder.  A child class is required to provide the "output
+    destination"
+ */
+class EncoderWriter : public IEncoder
+{
+protected:
+    /** Constructor. The size of the workBuffer determines how big of
+        'chunks' data is read from the "input source", i.e. it is a working
+        buffer and does NOT have to be the size of the maximum possible input
+        frame.
+     */
+    EncoderWriter( uint8_t startOfFrame, uint8_t endOfFrame, uint8_t escapeByte, bool skipSendingSof = false )
+        : m_sof( startOfFrame )
+        , m_eof( endOfFrame )
+        , m_esc( escapeByte )
+        , m_skipSendingSof( skipSendingSof )
+    {
+        KIT_SYSTEM_ASSERT( m_sof != m_eof );
+        KIT_SYSTEM_ASSERT( m_sof != m_esc );
+        KIT_SYSTEM_ASSERT( m_eof != m_esc );
+    }
+
+public:
+    /// See Kit::Framing::IEncoder
+    bool startFrame( void ) noexcept override;
+
+    /// See Kit::Framing::IEncoder
+    bool output( const void* srcBuffer, Kit::Type::SSize_T numBytes ) noexcept override;
+
+    /// See Kit::Framing::IEncoder
+    bool endFrame( void ) noexcept override;
+
+protected:
+    /** Used to initialize the "frame output sequence". Returns true if
+        successful; else false is returned.
+    */
+    virtual bool startOutput() noexcept = 0;
+
+    /** Outputs a new/next byte to the destination.
+        Returns true if successful; else false is returned.
+    */
+    virtual bool appendOutput( uint8_t srcByte ) noexcept = 0;
+
+    /** Used to finalize the "frame output sequence". Returns true if
+        successful; else false is returned.
+
+        NOTE: There is NO guarantee that endOutput() will always be called
+              before starting a new frame.  What is guaranteed is that startOutput()
+              will be called with each new attempted frame output sequence.
+    */
+    virtual bool endOutput() noexcept = 0;
+
+    /** Returns the encoded/escaped value for the specified special character.
+        The default implementation simply returns 'byteToBeEscaped'
+     */
+    virtual uint8_t encodeEscapedByte( uint8_t byteToBeEscaped ) noexcept;
+
+protected:
+    /// Start-of-Frame character
+    uint8_t m_sof;
+
+    /// End-of-Frame character
+    uint8_t m_eof;
+
+    /// Escape character
+    uint8_t m_esc;
+
+    /// Flag: I am currently in a Frame
+    bool m_inFrame;
+
+    /** Flag: Skip sending Start-of-Frame character. This flag should ONLY be
+        set when the child class's framing protocol supports multiple SOF characters.
+        See TBD as example of such a protocol.
+     */
+    bool m_skipSendingSof;
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Framing/IDecoder.h
+++ b/src/Kit/Framing/IDecoder.h
@@ -74,6 +74,6 @@ public:
 };
 
 
-};  // end namespaces
-};
+}  // end namespaces
+}
 #endif  // end header latch

--- a/src/Kit/Framing/IDecoder.h
+++ b/src/Kit/Framing/IDecoder.h
@@ -64,7 +64,7 @@ public:
         Returns true if successful, or false if End-of-Stream was encountered or
         if the input source is in a frame.
      */
-    virtual bool oobRead( uint8_t*            buffer,
+    virtual bool oobRead( uint8_t*            dstBuffer,
                           Kit::Type::SSize_T  numBytes,
                           Kit::Type::SSize_T& bytesRead ) noexcept = 0;
 

--- a/src/Kit/Framing/IDecoder.h
+++ b/src/Kit/Framing/IDecoder.h
@@ -26,10 +26,10 @@ class IDecoder
 public:
     /** This method reads from an Input source (which is defined/provided by
         the concrete implementation) until a valid frame is found or an error
-        occurred.  If a valid frame was found, true will be returned and the
-        frame will be stored in 'frameBuffer'.  The length, in bytes, of the frame found
-        is returned via 'frameSize'.  False is returned if a error was
-        encountered while reading the Input source.
+        occurred (i.e. a blocking call).  If a valid frame was found, true will
+        be returned and the frame will be stored in 'frameBuffer'.  The length,
+        in bytes, of the frame found is returned via 'frameSize'.  False is
+        returned if a error was encountered while reading the Input source.
      */
     virtual bool scan( Kit::Type::SSize_T  maxSizeOfFrameBuffer,
                        uint8_t*            frameBuffer,

--- a/src/Kit/Framing/IDecoder.h
+++ b/src/Kit/Framing/IDecoder.h
@@ -1,0 +1,79 @@
+#ifndef KIT_FRAMING_IDECODER_H_
+#define KIT_FRAMING_IDECODER_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Type/SSize.h"
+
+
+///
+namespace Kit {
+///
+namespace Framing {
+
+/** This abstract class defines an interface for 'receiving' (decoding) a frame.
+    See the README.md file for details about a what a Frame is
+ */
+class IDecoder
+{
+public:
+    /** This method reads from an Input source (which is defined/provided by
+        the concrete implementation) until a valid frame is found or an error
+        occurred.  If a valid frame was found, true will be returned and the
+        frame will be stored in 'frameBuffer'.  The length, in bytes, of the frame found
+        is returned via 'frameSize'.  False is returned if a error was
+        encountered while reading the Input source.
+     */
+    virtual bool scan( Kit::Type::SSize_T  maxSizeOfFrameBuffer,
+                       uint8_t*            frameBuffer,
+                       Kit::Type::SSize_T& frameSize ) noexcept = 0;
+
+    /** This method is similar to the above scan() method, except that it does
+        NOT block till a 'frame' has found, instead it indicates when a 'frame'
+        has been found by setting the 'isEof' flag to true.
+
+        False is returned if a error was encountered while reading the Input
+        source.
+     */
+    virtual bool scan( Kit::Type::SSize_T  maxSizeOfFrameBuffer,
+                       uint8_t*            frameBuffer,
+                       Kit::Type::SSize_T& frameSize,
+                       bool&               isEof ) noexcept = 0;
+
+public:
+    /** This method allows 'out-of-band' reading of the input source.  If the
+        scanner is in-a-frame the method return false and does nothing.
+
+        CAUTION: Most client/consumers of the decoder should never use this
+                 method.  This method only has meaning/usefulness when the
+                 application KNOWS when the input source is NOT in a frame AND
+                 that there is 'non-framed' data that can be consumed.
+
+        Attempts to read the specified number of bytes from the stream into the
+        supplied buffer.  The caller is responsible for ensuring that the buffer
+        is large enough to hold 'numBytes'. The actual number of bytes read is
+        returned via 'bytesRead'.
+
+        Returns true if successful, or false if End-of-Stream was encountered or
+        if the input source is in a frame.
+     */
+    virtual bool oobRead( uint8_t*            buffer,
+                          Kit::Type::SSize_T  numBytes,
+                          Kit::Type::SSize_T& bytesRead ) noexcept = 0;
+
+public:
+    /// Virtual Destructor
+    virtual ~IDecoder() = default;
+};
+
+
+};  // end namespaces
+};
+#endif  // end header latch

--- a/src/Kit/Framing/IDestination.h
+++ b/src/Kit/Framing/IDestination.h
@@ -1,0 +1,64 @@
+#ifndef KIT_FRAMING_IDESTINATION_H_
+#define KIT_FRAMING_IDESTINATION_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Type/SSize.h"
+
+
+///
+namespace Kit {
+///
+namespace Framing {
+
+/** This abstract class defines an interface of the output destination for an
+    Encoder instance. The concrete instance determines the 'destination', e.g. a
+    Stream, RAM buffer, etc.
+ */
+class IDestination
+{
+public:
+    /** Used to initialize the "frame output sequence".
+        Returns true if successful, false if no space is available
+        in the destination, or an error was encountered.
+    */
+    virtual bool startOutput() noexcept = 0;
+
+    /** Outputs the next N bytes to the destination.
+        Returns true if successful, false if 'no space' is available
+        in the destination, or an error was encountered.
+    */
+    virtual bool appendOutput( const void* srcBuffer, Kit::Type::SSize_T numBytes ) noexcept = 0;
+
+    /** Convenience/Alias method to output a single byte at a time */
+    inline bool appendOutput( uint8_t srcByte ) noexcept
+    {
+        return appendOutput( &srcByte, 1 );
+    }
+
+    /** Used to finalize the "frame output sequence".
+        Returns true if successful, false if 'no space' is available
+        in the destination, or an error was encountered.
+
+        NOTE: There is NO guarantee that endOutput() will always be called
+              before starting a new frame.  What is guaranteed is that startOutput()
+              will be called with each new attempted frame output sequence.
+    */
+    virtual bool endOutput() noexcept = 0;
+
+public:
+    /// Virtual Destructor
+    virtual ~IDestination() = default;
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Framing/IEncoder.h
+++ b/src/Kit/Framing/IEncoder.h
@@ -1,0 +1,75 @@
+#ifndef KIT_FRAMING_IENCODER_H_
+#define KIT_FRAMING_IENCODER_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Type/SSize.h"
+
+
+///
+namespace Kit {
+///
+namespace Framing {
+
+/** This abstract class defines an interface for 'creating/ouput' (encoding) a
+    frame.  The concrete instance determines the output destination, e.g. a
+    Stream, RAM buffer, etc. See the README.md file for details about a what a
+    Frame is.
+ */
+class IEncoder
+{
+public:
+    /** Begins the frame.  The method will return false if there an
+        error occurred while writing to the output destination; else true is
+        returned.  If this method is called twice - without an intervening
+        call to endFrame() - a NEW frame is started and true is returned
+
+        NOTE: On error, the framing sequence is left in an undefined state
+              and should be re-started by calling startFrame()
+     */
+    virtual bool startFrame( void ) noexcept = 0;
+
+
+    /** Outputs 'numBytes' of data (from 'srcBuffer') to the output destination.
+        The  method will return false if there an error occurred while
+        writing to  the output destination; else true is returned.  If this
+        method is called without a previous call to startFrame(), i.e. the
+        frame has NOT been started, false is returned.
+
+        NOTE: On error, the framing sequence is left in an undefined state
+              and should be re-started by calling startFrame()
+     */
+    virtual bool output( const void* srcBuffer, Kit::Type::SSize_T numBytes ) noexcept = 0;
+
+    /// Convenience/Alias method to output a single byte at a time
+    inline bool output( uint8_t srcByte ) noexcept
+    {
+        return output( &srcByte, 1 );
+    }
+
+    /** Ends the frame.  The method will return false if there an error
+        occurred while writing to the output destination; else true is
+        returned.  If this method is called twice - without an intervening
+        call to startFrame() - false is returned.
+
+        NOTE: On error, the framing sequence is left in an undefined state
+              and should be re-started by calling startFrame()
+     */
+    virtual bool endFrame( void ) noexcept = 0;
+
+public:
+    /// Virtual Destructor
+    virtual ~IEncoder() = default;
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Framing/ISource.h
+++ b/src/Kit/Framing/ISource.h
@@ -1,0 +1,47 @@
+#ifndef KIT_FRAMING_ISOURCE_H_
+#define KIT_FRAMING_ISOURCE_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Type/SSize.h"
+
+
+///
+namespace Kit {
+///
+namespace Framing {
+
+/** This abstract class defines an interface of the input source for a Decoder
+    instance. The concrete instance determines the 'source', e.g. a
+    Stream, RAM buffer, etc.
+ */
+class ISource
+{
+
+
+public:
+    /** Attempts to read the specified number of bytes from the "input source"
+        into the supplied buffer.  The actual number of bytes read is returned via
+        'bytesRead'. Returns true if successful, false if no more data is currently
+        available or an error was encountered.
+     */
+    virtual bool read( void*               dstBuffer,
+                       Kit::Type::SSize_T  numBytes,
+                       Kit::Type::SSize_T& bytesRead ) noexcept = 0;
+
+public:
+    /// Virtual Destructor
+    virtual ~ISource() = default;
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Framing/LineDecoder.cpp
+++ b/src/Kit/Framing/LineDecoder.cpp
@@ -1,0 +1,97 @@
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "LineDecoder.h"
+
+
+//------------------------------------------------------------------------------
+namespace Kit {
+namespace Framing {
+    
+void LineDecoder::initializeScan() noexcept
+{
+    DecoderReader::initializeScan();
+    m_frameDetected = false;
+}
+
+bool LineDecoder::isStartOfFrame( uint8_t byte ) noexcept
+{
+    // Reset my frame flag when encountering an newline
+    if ( isEndOfFrame( byte ) )
+    {
+        m_frameDetected = false;
+    }
+
+    // Skip printable ASCII characters if the frame was aborted due to an non printable
+    // character. Requires EOF to be encountered before accepting a new SOF character.
+    if ( !m_frameDetected )
+    {
+        // Convert tabs
+        convertTabs( byte );
+
+        // Printable ASCII character?
+        if ( byte >= ' ' && byte <= '~' )
+        {
+            // Adjust my internal data pointer/len since I am NOT discarding the SOF character
+            m_dataPtr--;
+            m_dataLen++;
+            m_frameDetected = true;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool LineDecoder::isEndOfFrame( uint8_t byte ) noexcept
+{
+    return byte == '\r' || byte == '\n';
+}
+
+bool LineDecoder::isEscapeByte( uint8_t byte ) noexcept
+{
+    return false;
+}
+
+bool LineDecoder::isLegalByte( uint8_t byte ) noexcept
+{
+    // Convert tabs to whitespace
+    convertTabs( byte );
+
+    // Newline is always 'valid'
+    if ( isEndOfFrame( byte ) )
+    {
+        m_frameDetected = false;
+        return true;
+    }
+
+    // Reject non-printable ASCII characters
+    if ( byte < ' ' || byte > '~' )
+    {
+        return false;
+    }
+
+    // If I get here character is a printable ASCII character
+    return true;
+}
+
+// Convert tab to space - when requested
+void LineDecoder::convertTabs( uint8_t& incomingByte ) noexcept
+{
+    if ( m_convertTabs != '\t' && incomingByte == '\t' )
+    {
+        incomingByte = m_convertTabs;
+        *m_dataPtr   = m_convertTabs;  // Tab was converted -->update the decoder's internal buffer with the converted value
+    }
+}
+
+}  // end namespace
+}
+//------------------------------------------------------------------------------

--- a/src/Kit/Framing/LineDecoder.h
+++ b/src/Kit/Framing/LineDecoder.h
@@ -44,11 +44,11 @@ public:
               does NOT have to be the size of the maximum possible input frame.
 
             - If the 'convertTabs' argument is set to a value OTHER than a tab
-              character ('\t'), then any tab characters encounter will be
-              converted to the value of 'convertTabs'. If 'convertTabs' is set
-              to a tab character, then tabs are not converted - which means that
-              if tabs are encountered, they will be treated as a non-printable
-              character and cause the current frame to be aborted.
+              character, then any tab characters encounter will be converted to
+              the value of 'convertTabs'. If 'convertTabs' is set to a tab 
+              character, then tabs are not converted - which means that if tabs
+              are encountered, they will be treated as a non-printable character
+              and cause the current frame to be aborted.
      */
     LineDecoder( ISource&           source,
                  uint8_t*           workBuffer,

--- a/src/Kit/Framing/LineDecoder.h
+++ b/src/Kit/Framing/LineDecoder.h
@@ -1,0 +1,95 @@
+#ifndef KIT_FRAMING_LINE_DECODER_H_
+#define KIT_FRAMING_LINE_DECODER_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Framing/DecoderReader.h"
+#include "Kit/System/Assert.h"
+
+///
+namespace Kit {
+///
+namespace Framing {
+
+/** This concrete template class extends the DecoderReader where a frame
+    consider one line of PRINTABLE ASCII text followed by a newline character.
+
+    ANY printable ASCII character is accepted as start-of-frame. And end-of-frame
+    is a newline character (`\r` or `\n`).  There is NO escape sequence since the
+    escape sequence is need to embedded EOF characters - but in this case EOF
+    (newline) is NOT a printable ASCII character -->so an escape sequence is
+    not meaningful.
+
+    This class is NOT thread safe.
+
+    NOTE: If a non-printable ASCII character is encounter within a frame, the
+          current frame is aborted AND a newline character is required before
+          accepting/detecting a new SOF character(s).
+
+ */
+class LineDecoder : public DecoderReader
+{
+public:
+    /** Constructor.
+        NOTES:
+            - The size of the workBuffer determines how big of 'chunks' data is
+              read from the "input source", i.e. it is a working buffer and
+              does NOT have to be the size of the maximum possible input frame.
+
+            - If the 'convertTabs' argument is set to a value OTHER than a tab
+              character ('\t'), then any tab characters encounter will be
+              converted to the value of 'convertTabs'. If 'convertTabs' is set
+              to a tab character, then tabs are not converted - which means that
+              if tabs are encountered, they will be treated as a non-printable
+              character and cause the current frame to be aborted.
+     */
+    LineDecoder( ISource&           source,
+                 uint8_t*           workBuffer,
+                 Kit::Type::SSize_T sizeOfWorkBuffer,
+                 char               convertTabs = '\t' )
+        : DecoderReader( source, workBuffer, sizeOfWorkBuffer )
+        , m_frameDetected( false )
+        , m_convertTabs( convertTabs )
+    {
+        KIT_SYSTEM_ASSERT( convertTabs == '\t' || ( convertTabs >= ' ' && convertTabs <= '~' ) );
+    }
+
+protected:
+    /// See Kit::Framing::IDecoder
+    bool isStartOfFrame( uint8_t byte ) noexcept override;
+
+    /// See Kit::Framing::IDecoder
+    bool isEndOfFrame( uint8_t byte ) noexcept override;
+
+    /// See Kit::Framing::IDecoder
+    bool isEscapeByte( uint8_t byte ) noexcept override;
+
+    /// See Kit::Framing::IDecoder
+    bool isLegalByte( uint8_t byte ) noexcept override;
+
+    /// See Kit::Framing::DecoderReader
+    void initializeScan() noexcept override;
+
+protected:
+    /// Helper method to convert tabs when requested
+    void convertTabs( uint8_t& incomingByte ) noexcept;
+
+protected:
+    /// Track if I have encountered SOF character(s) without an EOF character
+    bool m_frameDetected;
+
+    /// Remember my tabs option
+    char m_convertTabs;
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Framing/LineDecoderAllocate.h
+++ b/src/Kit/Framing/LineDecoderAllocate.h
@@ -17,7 +17,7 @@ namespace Kit {
 ///
 namespace Framing {
 
-/** This concrete convience template class extends the LineDecoder to include
+/** This concrete convenience template class extends the LineDecoder to include
     allocating the work buffer for the LineDecoder.
  */
 template <int SIZE_OF_WORK_BUFFER>

--- a/src/Kit/Framing/LineDecoderAllocate.h
+++ b/src/Kit/Framing/LineDecoderAllocate.h
@@ -1,0 +1,43 @@
+#ifndef KIT_FRAMING_LINE_DECODER_ALLOCATE_H_
+#define KIT_FRAMING_LINE_DECODER_ALLOCATE_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Framing/LineDecoder.h"
+
+///
+namespace Kit {
+///
+namespace Framing {
+
+/** This concrete convience template class extends the LineDecoder to include
+    allocating the work buffer for the LineDecoder.
+ */
+template <int SIZE_OF_WORK_BUFFER>
+class LineDecoderAllocate : public LineDecoder
+{
+public:
+    /** Constructor. See LineDecoder for details about the arguments.
+     */
+    LineDecoderAllocate( ISource& source,
+                         char     convertTabs = '\t' )
+        : LineDecoder( source, m_workBuffer, sizeof( m_workBuffer ), convertTabs )
+    {
+    }
+
+protected:
+    /// Work buffer for the LineDecoder
+    uint8_t m_workBuffer[SIZE_OF_WORK_BUFFER];
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Framing/README.md
+++ b/src/Kit/Framing/README.md
@@ -1,0 +1,41 @@
+# Kit::Framing
+@brief namespace description for Kit::Framing
+@namespace Kit::Framing @brief
+
+The Framing namespace provides interfaces for encoding and decoding streams
+of data. A text frame is a sequence of bytes that are bounded by a unique
+start-of-frame (SOF) and end-of-frame (EOF) byte.  There is also an 'escape`
+(ESC) byte that is used when to transform a SOF, EOF, ESC bytes into a two
+byte sequence so that SOF/EOF/ESC bytes are unique within a frame.
+
+Below are some examples:
+
+```
+    Framing characters:
+    Given:
+        SOF:= '.'
+        EOF:= ';'
+        ESC:= '~'
+
+
+        Raw Stream      Decoded Sequence(s)
+        -----------     --------------------
+        ".abcde;"       "abcde"
+        ".a;.b;.;"      "a", "b", ""
+        ".a;b.c;"       "a", "c"
+        ".a~;bcd"       "a;bcd"
+        ".~~;"          "~"
+        ".a.bcd;"       "a.bcd"
+        ".a~.bcd;"      "a.bcd"
+```
+
+Notes:
+
+- The quotes (") in the above example are NOT part of the frame and/or character
+  sequences - the quotes are only used to illustrate sets of characters.
+
+- The SOF character does not need to be escaped within a frame because once a
+  SOF has been found - the SOF character is NOT looked/scanned for until after
+  an EOF character has been detected.  Escaping an SOF character within a frame
+  will behave as expected, i.e. same behavior/semantics as escaping the EOF
+  character.

--- a/src/Kit/Framing/README.md
+++ b/src/Kit/Framing/README.md
@@ -32,3 +32,8 @@ Notes:
 
 - The quotes (") in the above example are NOT part of the frame and/or character
   sequences - the quotes are only used to illustrate sets of characters.
+
+- If an unescaped start-of-frame byte is encounter within a frame, the current
+  in-progress frame is discarded, and a new frame is started.
+
+- The SOF, EOF, and ESC bytes **must** all be unique values.

--- a/src/Kit/Framing/README.md
+++ b/src/Kit/Framing/README.md
@@ -23,9 +23,8 @@ Below are some examples:
         ".abcde;"       "abcde"
         ".a;.b;.;"      "a", "b", ""
         ".a;b.c;"       "a", "c"
-        ".a~;bcd"       "a;bcd"
+        ".a~;bcd;"      "a;bcd"
         ".~~;"          "~"
-        ".a.bcd;"       "a.bcd"
         ".a~.bcd;"      "a.bcd"
 ```
 
@@ -33,9 +32,3 @@ Notes:
 
 - The quotes (") in the above example are NOT part of the frame and/or character
   sequences - the quotes are only used to illustrate sets of characters.
-
-- The SOF character does not need to be escaped within a frame because once a
-  SOF has been found - the SOF character is NOT looked/scanned for until after
-  an EOF character has been detected.  Escaping an SOF character within a frame
-  will behave as expected, i.e. same behavior/semantics as escaping the EOF
-  character.

--- a/src/Kit/Framing/StreamDestination.h
+++ b/src/Kit/Framing/StreamDestination.h
@@ -1,0 +1,79 @@
+#ifndef KIT_FRAMING_STREAMDESTINATION_H_
+#define KIT_FRAMING_STREAMDESTINATION_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Framing/IDestination.h"
+#include "Kit/Io/IOutput.h"
+
+///
+namespace Kit {
+///
+namespace Framing {
+
+/** This concrete class implements the IDestination interface using a Kit::Io::Output
+    instance.
+
+    This class is NOT thread-safe.
+ */
+class StreamDestination : public IDestination
+{
+public:
+    /// Constructor
+    StreamDestination( Kit::Io::IOutput& outputStream ) noexcept
+        : m_dstPtr( &outputStream )
+    {
+    }
+
+    /// Constructor
+    StreamDestination() noexcept
+        : m_dstPtr( nullptr )
+    {
+    }
+
+    /// Allows the consumer to change/set the Output stream after construction
+    void setOutput( Kit::Io::IOutput& outputStream ) noexcept
+    {
+        m_dstPtr = &outputStream;
+    }
+
+public:
+    /// See Kit::Framing::IDestination
+    bool startOutput() noexcept override
+    {
+        return m_dstPtr != nullptr;  // No special handling needed to 'start' the output sequence for a stream
+    }
+
+    /// See Kit::Framing::IDestination
+    bool appendOutput( const void* srcBuffer, Kit::Type::SSize_T numBytes ) noexcept override
+    {
+        if ( srcBuffer == nullptr || m_dstPtr == nullptr )
+        {
+            return false;
+        }
+
+        return m_dstPtr->write( srcBuffer, numBytes );
+    }
+
+    /// See Kit::Framing::IDestination
+    bool endOutput() noexcept override
+    {
+        return m_dstPtr != nullptr;  // No special handling needed to 'end' the output sequence for a stream
+    }
+
+protected:
+    /// Underlying stream output stream
+    Kit::Io::IOutput* m_dstPtr;
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Framing/StreamSource.h
+++ b/src/Kit/Framing/StreamSource.h
@@ -1,0 +1,72 @@
+#ifndef KIT_FRAMING_STREAM_SOURCE_H_
+#define KIT_FRAMING_STREAM_SOURCE_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Framing/ISource.h"
+#include "Kit/Io/IInput.h"
+
+
+///
+namespace Kit {
+///
+namespace Framing {
+
+/** This concrete class implements the ISource interface using a Kit::Io::IInput
+    instance.
+
+    This class is NOT thread-safe.
+ */
+class StreamSource : public ISource
+{
+public:
+    /// Constructor
+    StreamSource( Kit::Io::IInput& inputStream ) noexcept
+        : m_srcPtr( &inputStream )
+    {
+    }
+
+    /// Constructor
+    StreamSource() noexcept
+        : m_srcPtr( nullptr )
+    {
+    }
+
+    /// Allows the consumer to change/set the Input stream after construction
+    void setInput( Kit::Io::IInput& inputStream ) noexcept
+    {
+        m_srcPtr = &inputStream;
+    }
+
+public:
+    /// See Kit::Framing::ISource
+     bool read( void*               dstBuffer,
+                Kit::Type::SSize_T  numBytes,
+                Kit::Type::SSize_T& bytesRead ) noexcept override
+    {
+        // Validate parameters and do NOT allow the read call to block if no data is currently available
+        if ( dstBuffer == nullptr || m_srcPtr == nullptr || m_srcPtr->available() == false )
+        {
+            bytesRead = 0;
+            return false;
+        }
+
+        return m_srcPtr->read( dstBuffer, numBytes, bytesRead );
+    }
+
+protected:
+    /// Underlying input stream
+    Kit::Io::IInput* m_srcPtr;
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Framing/StringDestination.h
+++ b/src/Kit/Framing/StringDestination.h
@@ -1,0 +1,85 @@
+#ifndef KIT_FRAMING_STRINGDESTINATION_H_
+#define KIT_FRAMING_STRINGDESTINATION_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Framing/IDestination.h"
+#include "Kit/Text/IString.h"
+
+///
+namespace Kit {
+///
+namespace Framing {
+
+/** This concrete class implements the IDestination interface using a Kit::Text::IString
+    instance.
+
+    This class is NOT thread-safe.
+ */
+class StringDestination : public IDestination
+{
+public:
+    /// Constructor
+    StringDestination( Kit::Text::IString& outputString ) noexcept
+        : m_dstPtr( &outputString )
+    {
+    }
+
+    /// Constructor
+    StringDestination() noexcept
+        : m_dstPtr( nullptr )
+    {
+    }
+
+    /// Allows the consumer to change/set the Output string after construction
+    void setOutput( Kit::Text::IString& outputString ) noexcept
+    {
+        m_dstPtr = &outputString;
+    }
+
+public:
+    /// See Kit::Framing::IDestination
+    bool startOutput() noexcept override
+    {
+        if ( m_dstPtr == nullptr )
+        {
+            return false;
+        }
+        m_dstPtr->clear();
+        return true;
+    }
+
+    /// See Kit::Framing::IDestination
+    bool appendOutput( const void* srcBuffer, Kit::Type::SSize_T numBytes ) noexcept override
+    {
+        if ( srcBuffer == nullptr || m_dstPtr == nullptr )
+        {
+            return false;
+        }
+
+        m_dstPtr->appendTo( static_cast<const char*>(srcBuffer), numBytes );
+        return m_dstPtr->truncated() == false;  // If truncated, then the entire buffer was not appended
+    }
+
+    /// See Kit::Framing::IDestination
+    bool endOutput() noexcept override
+    {
+        return m_dstPtr != nullptr;  // No special handling needed to 'end' the output sequence for a string
+    }
+
+protected:
+    /// Underlying string output
+    Kit::Text::IString* m_dstPtr;
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Framing/StringSource.h
+++ b/src/Kit/Framing/StringSource.h
@@ -1,5 +1,5 @@
-#ifndef KIT_FRAMING_STREAM_SOURCE_H_
-#define KIT_FRAMING_STREAM_SOURCE_H_
+#ifndef KIT_FRAMING_STRING_SOURCE_H_
+#define KIT_FRAMING_STRING_SOURCE_H_
 /*------------------------------------------------------------------------------
  * Copyright Integer Fox Authors
  *
@@ -57,7 +57,7 @@ public:
                Kit::Type::SSize_T& bytesRead ) noexcept override
     {
         // Validate parameters AND trap end-of-string has already been reached.
-        if ( dstBuffer == nullptr || m_srcPtr == nullptr || m_currentIdx < 0 )
+        if ( dstBuffer == nullptr || m_srcPtr == nullptr || m_currentIdx < 0 || numBytes < 0 )
         {
             bytesRead = 0;
             return false;

--- a/src/Kit/Framing/StringSource.h
+++ b/src/Kit/Framing/StringSource.h
@@ -1,0 +1,99 @@
+#ifndef KIT_FRAMING_STREAM_SOURCE_H_
+#define KIT_FRAMING_STREAM_SOURCE_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Framing/ISource.h"
+#include <string.h>
+
+///
+namespace Kit {
+///
+namespace Framing {
+
+/** This concrete class implements the ISource interface using a null terminated
+    string as the input source.  The string is not modified by this class.
+
+    This class is NOT thread-safe.
+ */
+class StringSource : public ISource
+{
+public:
+    /// Constructor
+    StringSource( const char* inputString ) noexcept
+        : m_srcPtr( inputString )
+        , m_currentIdx( 0 )
+        , m_length( inputString != nullptr ? strlen( inputString ) : 0 )
+    {
+    }
+
+    /// Constructor
+    StringSource() noexcept
+        : m_srcPtr( nullptr )
+        , m_currentIdx( 0 )
+        , m_length( 0 )
+    {
+    }
+
+    /// Allows the consumer to change/set the Input string after construction
+    void setInput( const char* inputString ) noexcept
+    {
+        m_srcPtr     = inputString;
+        m_currentIdx = 0;
+        m_length     = inputString != nullptr ? strlen( inputString ) : 0;
+    }
+
+public:
+    /// See Kit::Framing::ISource
+    bool read( void*               dstBuffer,
+               Kit::Type::SSize_T  numBytes,
+               Kit::Type::SSize_T& bytesRead ) noexcept override
+    {
+        // Validate parameters AND trap end-of-string has already been reached.
+        if ( dstBuffer == nullptr || m_srcPtr == nullptr || m_currentIdx < 0 )
+        {
+            bytesRead = 0;
+            return false;
+        }
+
+        // Determine how many bytes can been read
+        Kit::Type::SSize_T availableBytes = m_length - m_currentIdx;
+
+        // Requesting all of the remaining bytes
+        if ( numBytes >= availableBytes )
+        {
+            bytesRead = availableBytes;
+            memcpy( dstBuffer, m_srcPtr + m_currentIdx, availableBytes );
+            m_currentIdx = -1;  // Mark end of string reached
+            return true;
+        }
+
+        // Partial read of the remaining bytes
+        memcpy( dstBuffer, m_srcPtr + m_currentIdx, numBytes );
+        m_currentIdx += numBytes;
+        bytesRead     = numBytes;
+        return true;
+    }
+
+protected:
+    /// Underlying input string
+    const char* m_srcPtr;
+
+    /// Current read position within the input string. Negative value indicates the end of the string has been reached.
+    Kit::Type::SSize_T m_currentIdx;
+
+    /// Length of the input string (excluding the null terminator)
+    Kit::Type::SSize_T m_length;
+};
+
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/Framing/_0test/_0build/.gitignore
+++ b/src/Kit/Framing/_0test/_0build/.gitignore
@@ -1,0 +1,30 @@
+# Misc
+.html-report/
+.coverage.info
+cobertura.json
+jenkins-gcovr.xml
+*.gcov
+_posix64/
+_posix/
+_win32/
+_win64/
+_stm32/
+_arduino/
+ratt.log*
+
+# more stuff
+make.log
+*.gcda
+*.gcno
+*.idb
+*.pdb
+*.ilk
+*.lst
+*.map
+
+# visual studio
+*.ilk
+*.pdb
+*.sln
+
+*.user

--- a/src/Kit/Framing/_0test/_0build/libdirs.b
+++ b/src/Kit/Framing/_0test/_0build/libdirs.b
@@ -1,0 +1,11 @@
+src/Kit/Framing
+src/Kit/Framing/_0test
+
+src/Kit/Container
+src/Kit/System
+src/Kit/System/_trace
+src/Kit/System/_trace/_stdout
+src/Kit/Io
+
+src/Kit/System/_testsupport
+

--- a/src/Kit/Framing/_0test/_0build/libdirs.b
+++ b/src/Kit/Framing/_0test/_0build/libdirs.b
@@ -6,6 +6,7 @@ src/Kit/System
 src/Kit/System/_trace
 src/Kit/System/_trace/_stdout
 src/Kit/Io
+src/Kit/Io/Ram
 src/Kit/Text
 
 src/Kit/System/_testsupport

--- a/src/Kit/Framing/_0test/_0build/libdirs.b
+++ b/src/Kit/Framing/_0test/_0build/libdirs.b
@@ -6,6 +6,7 @@ src/Kit/System
 src/Kit/System/_trace
 src/Kit/System/_trace/_stdout
 src/Kit/Io
+src/Kit/Text
 
 src/Kit/System/_testsupport
 

--- a/src/Kit/Framing/_0test/_0build/linux/gcc-host/build_catch2.py
+++ b/src/Kit/Framing/_0test/_0build/linux/gcc-host/build_catch2.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python3
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Get the xpackage root directory from environment variable
+    xpackage_root  = os.environ.get('NQBP_XPKGS_ROOT')
+
+    # Run the "real" script
+    script = os.path.join( xpackage_root, "nqbp2", "other", "compile_catch2_base.py" )
+    cmd = script + " " + " ".join(sys.argv[1:])
+    rc = os.system( cmd )
+    sys.exit( rc )

--- a/src/Kit/Framing/_0test/_0build/linux/gcc-host/kit_config.h
+++ b/src/Kit/Framing/_0test/_0build/linux/gcc-host/kit_config.h
@@ -1,0 +1,16 @@
+#ifndef KIT_CONFIG_H_
+#define KIT_CONFIG_H_
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Options' (see LConfig Pattern) */
+
+#define USE_KIT_SYSTEM_TRACE
+#define USE_KIT_SYSTEM_ASSERT
+#define KitTextToStringMaxUnsigned_T uint64_t
+#endif

--- a/src/Kit/Framing/_0test/_0build/linux/gcc-host/kit_map.h
+++ b/src/Kit/Framing/_0test/_0build/linux/gcc-host/kit_map.h
@@ -1,0 +1,22 @@
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Mappings'  
+
+          Note: Intentionally there is NO Header latch (see LHeader Pattern)
+                for why.
+*/
+
+// OSAL mappings
+#include "Kit/System/Posix/mappings.h"
+
+// strapi mapping
+#include "Kit/Text/_mappings/_posix/strapi.h"
+
+// IO mapping
+#include "Kit/Io/_mappings/_posix/mappings.h"

--- a/src/Kit/Framing/_0test/_0build/linux/gcc-host/libdirs.b
+++ b/src/Kit/Framing/_0test/_0build/linux/gcc-host/libdirs.b
@@ -1,0 +1,3 @@
+# Use common (across compilers) libdirs.b
+../libdirs.b
+../../libdirs.b

--- a/src/Kit/Framing/_0test/_0build/linux/gcc-host/mytoolchain.py
+++ b/src/Kit/Framing/_0test/_0build/linux/gcc-host/mytoolchain.py
@@ -1,0 +1,124 @@
+#---------------------------------------------------------------------------
+# This python module is used to customize a supported toolchain for your 
+# project specific settings.
+#
+# Notes:
+#    - ONLY edit/add statements in the sections marked by BEGIN/END EDITS
+#      markers.
+#    - Maintain indentation level and use spaces (it's a python thing) 
+#    - rvalues must be enclosed in quotes (single ' ' or double " ")
+#    - The structure/class 'BuildValues' contains (at a minimum the
+#      following data members.  Any member not specifically set defaults
+#      to null/empty string
+#            .inc             # C/C++ search path include directories 
+#            .asminc          # Assembly search path include directories
+#            .c_only_flags    # C only compiler flags
+#            .cflags          # C and C++ compiler flags
+#            .cppflags        # C++ only compiler flags
+#            .asmflags        # Assembly compiler flags
+#            .linkflags       # Linker flags
+#            .linklibs        # Linker libraries
+#            .firstobjs       # Object files to be unconditionally linked first
+#            .lastobjs        # Object files to be unconditionally linked last
+#           
+#---------------------------------------------------------------------------
+
+# get definition of the Options structure
+from nqbplib.base import BuildValues
+from nqbplib.my_globals import *
+from nqbplib.utils import config_catch2
+import os
+
+# Capture project/build directory
+prjdir = os.path.dirname(os.path.abspath(__file__))
+
+
+#===================================================
+# BEGIN EDITS/CUSTOMIZATIONS
+#---------------------------------------------------
+
+# Set the name for the final output item
+FINAL_OUTPUT_NAME = 'a.out'
+
+# Using Catch2
+(catch2_inc, catch2_lib, unit_test_objects) = config_catch2( prjdir, 'linux/gcc-host', 'a' )
+
+
+# 
+# For build config/variant: "posix64" 
+#
+
+# Construct option structs
+base_posix64      = BuildValues()
+optimized_posix64 = BuildValues()
+debug_posix64     = BuildValues()
+
+# Set project specific 'base' (i.e always used) options. Note: Catch2 requires C++17 or newer
+base_posix64.cflags    = '-m64 -std=c++17 -Wall -Werror -x c++ -fprofile-arcs -ftest-coverage -fprofile-update=atomic'
+base_posix64.inc       = catch2_inc
+base_posix64.firstobjs = unit_test_objects
+base_posix64.linkflags = '-m64 -fprofile-arcs'
+base_posix64.linklibs  = f'-lgcov {catch2_lib}'
+
+# Set project specific 'optimized' options
+optimized_posix64.cflags    = '-O3'
+
+# Set project specific 'debug' options
+
+
+#
+# For build config/variant: "posix32"
+#
+
+# Set project specific 'base' (i.e always used) options. Note: Catch2 requires C++17 or newer
+base_posix32           = BuildValues()        # Do NOT comment out this line
+base_posix32.cflags    = '-m32 -std=c++17 -Wall -Werror -x c++ -fprofile-arcs -ftest-coverage -fprofile-update=atomic'
+base_posix32.inc       = catch2_inc
+base_posix32.firstobjs = unit_test_objects
+base_posix32.linkflags = '-m32 -fprofile-arcs'
+base_posix32.linklibs  = f'-lgcov {catch2_lib}'
+
+
+# Set project specific 'optimized' options
+optimized_posix32           = BuildValues()    # Do NOT comment out this line
+optimized_posix32.cflags    = '-O3'
+
+# Set project specific 'debug' options
+debug_posix32           = BuildValues()       # Do NOT comment out this line
+
+
+
+#-------------------------------------------------
+# ONLY edit this section if you are have more than
+# ONE build configuration/variant 
+#-------------------------------------------------
+
+posix32_opts = { 'user_base':base_posix32, 
+                 'user_optimized':optimized_posix32, 
+                 'user_debug':debug_posix32
+               }
+               
+               
+posix64_opts = { 'user_base':base_posix64, 
+                 'user_optimized':optimized_posix64, 
+                 'user_debug':debug_posix64
+               }
+  
+        
+# Add new variant option dictionary to # dictionary of 
+# build variants
+build_variants = { 'posix':posix32_opts,
+                   'posix64':posix64_opts,
+                 }    
+
+#---------------------------------------------------
+# END EDITS/CUSTOMIZATIONS
+#===================================================
+
+# Select Module that contains the desired toolchain
+from nqbplib.toolchains.linux.gcc.console_exe import ToolChain
+
+# Function that instantiates an instance of the toolchain
+def create():
+    tc = ToolChain( FINAL_OUTPUT_NAME, prjdir, build_variants, "posix64" )
+    return tc 

--- a/src/Kit/Framing/_0test/_0build/linux/gcc-host/nqbp.py
+++ b/src/Kit/Framing/_0test/_0build/linux/gcc-host/nqbp.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+"""Invokes NQBP's mk.py script"""
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Make sure the environment is properly set
+    NQBP_BIN = os.environ.get('NQBP_BIN')
+    if ( NQBP_BIN is None ):
+        sys.exit( "ERROR: The environment variable NQBP_BIN is not set!" )
+    sys.path.append( NQBP_BIN )
+
+    # Find the Package & Workspace root
+    from nqbplib import utils
+    utils.set_pkg_and_wrkspace_roots(__file__)
+
+    # Call into core/common scripts
+    import mytoolchain
+    from nqbplib import mk
+    mk.build( sys.argv, mytoolchain.create() )
+

--- a/src/Kit/Framing/_0test/_0build/linux/gcc-host/sources.b
+++ b/src/Kit/Framing/_0test/_0build/linux/gcc-host/sources.b
@@ -1,0 +1,2 @@
+# share a common main
+../../main.cpp

--- a/src/Kit/Framing/_0test/_0build/linux/gcc-host/tca2.py
+++ b/src/Kit/Framing/_0test/_0build/linux/gcc-host/tca2.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python3
+"""Invokes NQBP's tca2_base.py script.  To run 'TCA2' copy this file to your build directory and the execute it."""
+
+from __future__ import absolute_import
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Make sure the environment is properly set
+    NQBP_BIN = os.environ.get('NQBP_BIN')
+    if ( NQBP_BIN is None ):
+        sys.exit( "ERROR: The environment variable NQBP_BIN is not set!" )
+    sys.path.append( NQBP_BIN )
+
+    # Find the Package & Workspace root
+    from nqbplib import utils
+    utils.set_pkg_and_wrkspace_roots(__file__)
+    here = os.path.dirname(os.path.abspath(__file__))
+
+    # Find the Package & Workspace root
+    from other import tca2_base
+    tca2_base.run( here, sys.argv )
+

--- a/src/Kit/Framing/_0test/_0build/linux/libdirs.b
+++ b/src/Kit/Framing/_0test/_0build/linux/libdirs.b
@@ -1,0 +1,6 @@
+# Platform
+src/Kit/System/Posix
+src/Kit/System/Posix/_fatalerror
+src/Kit/Text/_mappings/_posix
+src/Kit/System/Posix/_realtime
+src/Kit/Io/Stdio/Posix

--- a/src/Kit/Framing/_0test/_0build/main.cpp
+++ b/src/Kit/Framing/_0test/_0build/main.cpp
@@ -1,0 +1,18 @@
+#include "Kit/System/Api.h"
+#include "Kit/System/Trace.h"
+#include "catch2/catch_session.hpp"
+
+int main( int argc, char* argv[] )
+{
+    // Initialize KIT Library
+    Kit::System::initialize();
+
+    // Enable trace
+    KIT_SYSTEM_TRACE_ENABLE();
+    KIT_SYSTEM_TRACE_ENABLE_SECTION( "_0test" );
+    KIT_SYSTEM_TRACE_ENABLE_SECTION( "*LOG_" );
+    KIT_SYSTEM_TRACE_SET_INFO_LEVEL( Kit::System::Trace::eINFO );
+
+    // Run the test(s)
+    return Catch::Session().run( argc, argv );
+}

--- a/src/Kit/Framing/_0test/_0build/windows/clang-host/build_catch2.py
+++ b/src/Kit/Framing/_0test/_0build/windows/clang-host/build_catch2.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python3
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Get the xpackage root directory from environment variable
+    xpackage_root  = os.environ.get('NQBP_XPKGS_ROOT')
+
+    # Run the "real" script
+    script = os.path.join( xpackage_root, "nqbp2", "other", "compile_catch2_base.py" )
+    cmd = script + " " + " ".join(sys.argv[1:])
+    rc = os.system( cmd )
+    sys.exit( rc )

--- a/src/Kit/Framing/_0test/_0build/windows/clang-host/kit_config.h
+++ b/src/Kit/Framing/_0test/_0build/windows/clang-host/kit_config.h
@@ -1,0 +1,17 @@
+#ifndef KIT_CONFIG_H_
+#define KIT_CONFIG_H_
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Options' (see LConfig Pattern) */
+
+#define USE_KIT_SYSTEM_TRACE
+#define USE_KIT_SYSTEM_ASSERT
+#define KitTextToStringMaxUnsigned_T uint64_t
+
+#endif

--- a/src/Kit/Framing/_0test/_0build/windows/clang-host/kit_map.h
+++ b/src/Kit/Framing/_0test/_0build/windows/clang-host/kit_map.h
@@ -1,0 +1,22 @@
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Mappings'  
+
+          Note: Intentionally there is NO Header latch (see LHeader Pattern)
+                for why.
+*/
+
+// IO mapping.  Note: Needs to be include FIRST because of winsock2.h ordering issues
+#include "Kit/Io/_mappings/_win32/mappings.h"
+
+// OSAL mappings
+#include "Kit/System/Win32/mappings.h"
+
+// strapi mapping
+#include "Kit/Text/_mappings/_clang-msvc/strapi.h"

--- a/src/Kit/Framing/_0test/_0build/windows/clang-host/libdirs.b
+++ b/src/Kit/Framing/_0test/_0build/windows/clang-host/libdirs.b
@@ -1,0 +1,3 @@
+# Use common (across compilers) libdirs.b
+../libdirs.b
+../../libdirs.b

--- a/src/Kit/Framing/_0test/_0build/windows/clang-host/mytoolchain.py
+++ b/src/Kit/Framing/_0test/_0build/windows/clang-host/mytoolchain.py
@@ -1,0 +1,98 @@
+#---------------------------------------------------------------------------
+# This python module is used to customize a supported toolchain for your 
+# project specific settings.
+#
+# Notes:
+#    - ONLY edit/add statements in the sections marked by BEGIN/END EDITS
+#      markers.
+#    - Maintain indentation level and use spaces (it's a python thing) 
+#    - The structure/class 'BuildValues' contains (at a minimum the
+#      following data members.  Any member not specifically set defaults
+#      to null/empty string
+#            .inc             # C/C++ search path include directories 
+#            .asminc          # Assembly search path include directories
+#            .c_only_flags    # C only compiler flags
+#            .cflags          # C and C++ compiler flags
+#            .cppflags        # C++ only compiler flags
+#            .asmflags        # Assembly compiler flags
+#            .linkflags       # Linker flags
+#            .linklibs        # Linker libraries
+#            .firstobjs       # Object files to be unconditionally linked first
+#            .lastobjs        # Object files to be unconditionally linked last
+#           
+#---------------------------------------------------------------------------
+
+# get definition of the Options structure
+from nqbplib.base import BuildValues
+from nqbplib.my_globals import *
+from nqbplib.utils import config_catch2
+import os
+
+# Capture project/build directory
+prjdir = os.path.dirname(os.path.abspath(__file__))
+
+#===================================================
+# BEGIN EDITS/CUSTOMIZATIONS
+#---------------------------------------------------
+
+# Set the name for the final output item
+FINAL_OUTPUT_NAME = 'a.exe'
+
+# Using Catch2 
+(catch2_inc, catch2_lib, unit_test_objects) = config_catch2( prjdir, 'windows/clang-host', 'a' )
+
+
+
+#
+# For build config/variant: "win32"
+#
+
+# Construct option structs
+base_win32      = BuildValues()
+optimized_win32 = BuildValues()
+debug_win32     = BuildValues()
+
+# Set 'base' options
+base_win32.cflags     = '-m32 -std=c++17 -Wall -Werror -x c++ -D_CRT_SECURE_NO_WARNINGS'
+base_win32.inc        = catch2_inc
+base_win32.linkflags  = '-m32'
+base_win32.firstobjs  = unit_test_objects
+base_win32.linklibs   = f'{catch2_lib}'
+
+# Set 'Optimized' options
+optimized_win32.cflags    = '-O3'
+
+# Set 'debug' options
+
+
+
+#-------------------------------------------------
+# ONLY edit this section if you are have more than
+# ONE build configuration/variant 
+#-------------------------------------------------
+
+# Add new dictionary of for new build configuration options
+win32_opts = { 'user_base':base_win32,
+               'user_optimized':optimized_win32,
+               'user_debug':debug_win32
+             }
+               
+        
+# Add new variant option dictionary to # dictionary of 
+# build variants
+build_variants = { 'win32':win32_opts,
+                 }
+
+
+#---------------------------------------------------
+# END EDITS/CUSTOMIZATIONS
+#===================================================
+
+# Select Module that contains the desired toolchain
+from nqbplib.toolchains.windows.clang_msvc.console_exe import ToolChain
+
+
+# Function that instantiates an instance of the toolchain
+def create():
+    tc = ToolChain( FINAL_OUTPUT_NAME, prjdir, build_variants, "win32" )
+    return tc 

--- a/src/Kit/Framing/_0test/_0build/windows/clang-host/nqbp.py
+++ b/src/Kit/Framing/_0test/_0build/windows/clang-host/nqbp.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+"""Invokes NQBP's mk.py script"""
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Make sure the environment is properly set
+    NQBP_BIN = os.environ.get('NQBP_BIN')
+    if ( NQBP_BIN is None ):
+        sys.exit( "ERROR: The environment variable NQBP_BIN is not set!" )
+    sys.path.append( NQBP_BIN )
+
+    # Find the Package & Workspace root
+    from nqbplib import utils
+    utils.set_pkg_and_wrkspace_roots(__file__)
+
+    # Call into core/common scripts
+    import mytoolchain
+    from nqbplib import mk
+    mk.build( sys.argv, mytoolchain.create() )
+

--- a/src/Kit/Framing/_0test/_0build/windows/clang-host/sources.b
+++ b/src/Kit/Framing/_0test/_0build/windows/clang-host/sources.b
@@ -1,0 +1,2 @@
+# share a common main
+../../main.cpp

--- a/src/Kit/Framing/_0test/_0build/windows/libdirs.b
+++ b/src/Kit/Framing/_0test/_0build/windows/libdirs.b
@@ -1,0 +1,6 @@
+# Platform
+src/Kit/System/Win32
+src/Kit/System/Win32/_shutdown
+src/Kit/System/Win32/_fatalerror
+src/Kit/System/Win32/_realtime
+src/Kit/Io/Stdio/Win32

--- a/src/Kit/Framing/_0test/_0build/windows/msvc/build_catch2.py
+++ b/src/Kit/Framing/_0test/_0build/windows/msvc/build_catch2.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python3
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Get the xpackage root directory from environment variable
+    xpackage_root  = os.environ.get('NQBP_XPKGS_ROOT')
+
+    # Run the "real" script
+    script = os.path.join( xpackage_root, "nqbp2", "other", "compile_catch2_base.py" )
+    cmd = script + " " + " ".join(sys.argv[1:])
+    rc = os.system( cmd )
+    sys.exit( rc )

--- a/src/Kit/Framing/_0test/_0build/windows/msvc/kit_config.h
+++ b/src/Kit/Framing/_0test/_0build/windows/msvc/kit_config.h
@@ -1,0 +1,16 @@
+#ifndef KIT_CONFIG_H_
+#define KIT_CONFIG_H_
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Options' (see LConfig Pattern) */
+
+#define USE_KIT_SYSTEM_ASSERT
+#define KitTextToStringMaxUnsigned_T uint64_t
+
+#endif

--- a/src/Kit/Framing/_0test/_0build/windows/msvc/kit_map.h
+++ b/src/Kit/Framing/_0test/_0build/windows/msvc/kit_map.h
@@ -1,0 +1,22 @@
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Mappings'  
+
+          Note: Intentionally there is NO Header latch (see LHeader Pattern)
+                for why.
+*/
+
+// IO mapping.  Note: Needs to be include FIRST because of winsock2.h ordering issues
+#include "Kit/Io/_mappings/_win32/mappings.h"
+
+// OSAL mappings
+#include "Kit/System/Win32/mappings.h"
+
+// strapi mapping
+#include "Kit/Text/_mappings/_msvc/strapi.h"

--- a/src/Kit/Framing/_0test/_0build/windows/msvc/libdirs.b
+++ b/src/Kit/Framing/_0test/_0build/windows/msvc/libdirs.b
@@ -1,0 +1,3 @@
+# Use common (across compilers) libdirs.b
+../libdirs.b
+../../libdirs.b

--- a/src/Kit/Framing/_0test/_0build/windows/msvc/mytoolchain.py
+++ b/src/Kit/Framing/_0test/_0build/windows/msvc/mytoolchain.py
@@ -1,0 +1,91 @@
+#---------------------------------------------------------------------------
+# This python module is used to customize a supported toolchain for your 
+# project specific settings.
+#
+# Notes:
+#    - ONLY edit/add statements in the sections marked by BEGIN/END EDITS
+#      markers.
+#    - Maintain indentation level and use spaces (it's a python thing) 
+#    - The structure/class 'BuildValues' contains (at a minimum the
+#      following data members.  Any member not specifically set defaults
+#      to null/empty string
+#            .inc             # C/C++ search path include directories 
+#            .asminc          # Assembly search path include directories
+#            .c_only_flags    # C only compiler flags
+#            .cflags          # C and C++ compiler flags
+#            .cppflags        # C++ only compiler flags
+#            .asmflags        # Assembly compiler flags
+#            .linkflags       # Linker flags
+#            .linklibs        # Linker libraries
+#            .firstobjs       # Object files to be unconditionally linked first
+#            .lastobjs        # Object files to be unconditionally linked last
+#           
+#---------------------------------------------------------------------------
+
+# get definition of the Options structure
+from nqbplib.base import BuildValues
+from nqbplib.my_globals import *
+from nqbplib.utils import config_catch2
+import os
+
+# Capture project/build directory
+prjdir = os.path.dirname(os.path.abspath(__file__))
+
+#===================================================
+# BEGIN EDITS/CUSTOMIZATIONS
+#---------------------------------------------------
+
+# Set the name for the final output item
+FINAL_OUTPUT_NAME = 'a.exe'
+
+# Using Catch2 
+(catch2_inc, catch2_lib, unit_test_objects) = config_catch2( prjdir, 'windows/msvc', 'lib' )
+
+
+#
+# For build config/variant: "win32" 
+#
+
+# Set project specific 'base' (i.e always used) options. Note: Catch2 requires C++17 or newer
+base_win32           = BuildValues()        # Do NOT comment out this line
+base_win32.cflags    = '/W3 /WX /EHsc '  # /EHsc enables exceptions /std:c++17
+base_win32.firstobjs = unit_test_objects
+base_win32.inc       = catch2_inc
+base_win32.linklibs  = catch2_lib
+
+# Set project specific 'optimized' options
+optimized_win32          = BuildValues()    # Do NOT comment out this line
+optimized_win32.cflags   = '/O2'
+
+# Set project specific 'debug' options
+debug_win32          = BuildValues()       # Do NOT comment out this line
+debug_win32.cflags   = '/D "KIT_DEBUG"'
+
+
+#-------------------------------------------------
+# ONLY edit this section if you are have more than
+# ONE build configuration/variant 
+#-------------------------------------------------
+
+win32_build_opts = { 'user_base':base_win32, 
+                     'user_optimized':optimized_win32, 
+                     'user_debug':debug_win32
+                   }
+               
+# Add new variant option dictionary to # dictionary of 
+# build variants
+build_variants = { 'win32':win32_build_opts,
+                 }    
+
+#---------------------------------------------------
+# END EDITS/CUSTOMIZATIONS
+#===================================================
+
+
+# Select Module that contains the desired toolchain
+from nqbplib.toolchains.windows.vc12.console_exe import ToolChain
+
+# Function that instantiates an instance of the toolchain
+def create():
+    tc = ToolChain( FINAL_OUTPUT_NAME, prjdir, build_variants, 'win32' )
+    return tc 

--- a/src/Kit/Framing/_0test/_0build/windows/msvc/nqbp.py
+++ b/src/Kit/Framing/_0test/_0build/windows/msvc/nqbp.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+"""Invokes NQBP's mk.py script"""
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Make sure the environment is properly set
+    NQBP_BIN = os.environ.get('NQBP_BIN')
+    if ( NQBP_BIN is None ):
+        sys.exit( "ERROR: The environment variable NQBP_BIN is not set!" )
+    sys.path.append( NQBP_BIN )
+
+    # Find the Package & Workspace root
+    from nqbplib import utils
+    utils.set_pkg_and_wrkspace_roots(__file__)
+
+    # Call into core/common scripts
+    import mytoolchain
+    from nqbplib import mk
+    mk.build( sys.argv, mytoolchain.create() )
+

--- a/src/Kit/Framing/_0test/_0build/windows/msvc/sources.b
+++ b/src/Kit/Framing/_0test/_0build/windows/msvc/sources.b
@@ -1,0 +1,2 @@
+# share a common main
+../../main.cpp

--- a/src/Kit/Framing/_0test/decoderreader.cpp
+++ b/src/Kit/Framing/_0test/decoderreader.cpp
@@ -1,0 +1,234 @@
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/System/_testsupport/ShutdownUnitTesting.h"
+#include "catch2/catch_test_macros.hpp"
+#include "Kit/Text/BString.h"
+#include <string.h>
+
+
+///
+using namespace Kit::Text;
+using namespace Kit::System;
+
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_CASE( "BString" )
+{
+    ShutdownUnitTesting::clearAndUseCounter();
+    char     rawMemory0[11];
+    char     rawMemory1[6];
+    BString  foo( rawMemory0, sizeof( rawMemory0 ), "Hello World, this is bob" );
+    BString  bar( rawMemory1, sizeof( rawMemory1 ), "Hello World, this is bob" );
+    IString& bref = bar;
+
+
+    SECTION( "Some basic operation" )
+    {
+        REQUIRE( foo != bar );
+        REQUIRE( bar == bref );
+
+        /* 0123456789 */
+        foo.insertAt( 0, "HI" );
+        REQUIRE( foo == "HIHello Wo" );
+        foo.insertAt( -1, "HI" );
+        REQUIRE( foo == "HIHIHello " );
+        foo.insertAt( 9, "HI" );
+        REQUIRE( foo == "HIHIHelloH" );
+        foo.insertAt( 10, "!!" );
+        REQUIRE( foo == "HIHIHelloH" );
+        foo.insertAt( 5, "<*>" );
+        REQUIRE( foo == "HIHIH<*>el" );
+        foo = "123";
+        foo.insertAt( 10, "Bob's here" );
+        REQUIRE( foo == "123Bob's h" );
+        foo = "456";
+        foo.insertAt( 1, "Uncle" );
+        REQUIRE( foo == "4Uncle56" );
+    }
+
+    SECTION( "Constructors" )
+    {
+        const char* nullPtr = 0;
+        char        rawMemory2[4];
+        BString     s0( rawMemory2, sizeof( rawMemory2 ), nullPtr );
+        REQUIRE( s0 == "" );
+
+        char    rawMemory3[4];
+        BString s1( rawMemory3, sizeof( rawMemory3 ) );
+        REQUIRE( s1 == "" );
+
+        s1 = "uncle";
+        char    rawMemory4[4];
+        BString s2( rawMemory4, sizeof( rawMemory4 ), s1 );
+        REQUIRE( s2 == "unc" );
+
+        char    rawMemory5[4];
+        BString s3( rawMemory5, sizeof( rawMemory5 ), bref );
+        REQUIRE( s3 == "Hel" );
+
+        char    rawMemory6[4];
+        BString s4( rawMemory6, sizeof( rawMemory6 ), "abcdefghijklmnopqrstuvwxyz" );
+        REQUIRE( s4 == "abc" );
+
+        char    rawMemory7[4];
+        BString s5( rawMemory7, sizeof( rawMemory7 ), '@' );
+        REQUIRE( s5 == '@' );
+
+        char    rawMemory8[4];
+        BString s6( rawMemory8, sizeof( rawMemory8 ), -32 );
+        REQUIRE( s6 == "-32" );
+
+        char    rawMemory9[4];
+        BString s7( rawMemory9, sizeof( rawMemory9 ), (unsigned)42 );
+        REQUIRE( s7 == "42" );
+
+        char    rawMemory10[4];
+        BString s8( rawMemory10, sizeof( rawMemory10 ), (long)-10000000 );
+        REQUIRE( s8 == "-10" );
+
+
+        char    rawMemory11[4];
+        BString s9( rawMemory11, sizeof( rawMemory11 ), (unsigned long)81000000 );
+        REQUIRE( s9 == "810" );
+
+        char    rawMemory12[4];
+        BString s10( rawMemory12, sizeof( rawMemory12 ), (long long)-200000000000 );
+        REQUIRE( s10 == "-20" );
+
+
+        char    rawMemory13[4];
+        BString s11( rawMemory13, sizeof( rawMemory13 ), (unsigned long long)9100000000000 );
+        REQUIRE( s11 == "910" );
+
+        char    rawMemory14[2];
+        BString s12( rawMemory14, 0, "hello" );
+        REQUIRE( s12 == "" );
+
+        char    rawMemory15[6];
+        BString s13( rawMemory15, 1, "hello" );
+        REQUIRE( s13 == "" );
+
+        BString s14( nullptr, 2, "hello" );
+        REQUIRE( s14 == "" );
+    }
+
+    SECTION( "Assignments" )
+    {
+        const char* nullPtr = 0;
+        char        rawMemory2[4];
+        BString     s0( rawMemory2, sizeof( rawMemory2 ), "****" );
+        s0 = nullPtr;
+        REQUIRE( s0 == "" );
+
+        char    rawMemory3[4];
+        BString s1( rawMemory3, sizeof( rawMemory3 ), "****" );
+        s1 = "";
+        REQUIRE( s1 == "" );
+
+        s1 = "uncle";
+        char    rawMemory4[4];
+        BString s2( rawMemory4, sizeof( rawMemory4 ), "****" );
+        s2 = s1;
+        REQUIRE( s2 == "unc" );
+
+        char    rawMemory5[4];
+        BString s3( rawMemory5, sizeof( rawMemory5 ), "****" );
+        s3 = bref;
+        REQUIRE( s3 == "Hel" );
+
+        char    rawMemory6[4];
+        BString s4( rawMemory6, sizeof( rawMemory6 ), "****" );
+        s4 = "abcdefghijklmnopqrstuvwxyz";
+        REQUIRE( s4 == "abc" );
+
+        char    rawMemory7[4];
+        BString s5( rawMemory7, sizeof( rawMemory7 ), "****" );
+        s5 = '@';
+        REQUIRE( s5 == '@' );
+
+        char    rawMemory8[4];
+        BString s6( rawMemory8, sizeof( rawMemory8 ), "****" );
+        s6 = -32;
+        REQUIRE( s6 == "-32" );
+
+        char    rawMemory9[4];
+        BString s7( rawMemory9, sizeof( rawMemory9 ), "****" );
+        s7 = (unsigned)42;
+        REQUIRE( s7 == "42" );
+
+        char    rawMemory10[4];
+        BString s8( rawMemory10, sizeof( rawMemory10 ), "****" );
+        s8 = (long)-10000000;
+        REQUIRE( s8 == "-10" );
+
+        char    rawMemory11[4];
+        BString s9( rawMemory11, sizeof( rawMemory11 ), "****" );
+        s9 = (unsigned long)81000000;
+        REQUIRE( s9 == "810" );
+    }
+
+    SECTION( "Append" )
+    {
+        const char* nullPtr = 0;
+        char        rawMemory2[9];
+        BString     s0( rawMemory2, sizeof( rawMemory2 ), "****" );
+        s0 += nullPtr;
+        REQUIRE( s0 == "****" );
+
+        char    rawMemory3[9];
+        BString s1( rawMemory3, sizeof( rawMemory3 ), "****" );
+        s1 += "";
+        REQUIRE( s1 == "****" );
+
+        s1 = "uncle";
+        char    rawMemory4[9];
+        BString s2( rawMemory4, sizeof( rawMemory4 ), "****" );
+        s2 += s1;
+        REQUIRE( s2 == "****uncl" );
+
+        char    rawMemory5[9];
+        BString s3( rawMemory5, sizeof( rawMemory5 ), "****" );
+        s3 += bref;
+        REQUIRE( s3 == "****Hell" );
+
+        char    rawMemory6[9];
+        BString s4( rawMemory6, sizeof( rawMemory6 ), "****" );
+        s4 += "abcdefghijklmnopqrstuvwxyz";
+        REQUIRE( s4 == "****abcd" );
+
+        char    rawMemory7[9];
+        BString s5( rawMemory7, sizeof( rawMemory7 ), "****" );
+        s5 += '@';
+        REQUIRE( s5 == "****@" );
+
+        char    rawMemory8[9];
+        BString s6( rawMemory8, sizeof( rawMemory8 ), "****" );
+        s6 += -32;
+        REQUIRE( s6 == "****-32" );
+
+        char    rawMemory9[9];
+        BString s7( rawMemory9, sizeof( rawMemory9 ), "****" );
+        s7 += (unsigned)42;
+        REQUIRE( s7 == "****42" );
+
+        char    rawMemory10[9];
+        BString s8( rawMemory10, sizeof( rawMemory10 ), "****" );
+        s8 += (long)-10000000;
+        REQUIRE( s8 == "****-100" );
+
+        char    rawMemory11[9];
+        BString s9( rawMemory11, sizeof( rawMemory11 ), "****" );
+        s9 += (unsigned long)81000000;
+        REQUIRE( s9 == "****8100" );
+    }
+
+    REQUIRE( ShutdownUnitTesting::getAndClearCounter() == 0u );
+}

--- a/src/Kit/Framing/_0test/decoderreader.cpp
+++ b/src/Kit/Framing/_0test/decoderreader.cpp
@@ -13,7 +13,7 @@
 #include "Kit/Framing/DecoderReader.h"
 #include "Kit/Framing/ISource.h"
 #include <string.h>
-
+#include <algorithm>
 
 ///
 using namespace Kit::System;

--- a/src/Kit/Framing/_0test/decoderreader.cpp
+++ b/src/Kit/Framing/_0test/decoderreader.cpp
@@ -11,6 +11,7 @@
 #include "Kit/System/_testsupport/ShutdownUnitTesting.h"
 #include "catch2/catch_test_macros.hpp"
 #include "Kit/Framing/DecoderReader.h"
+#include "Kit/Framing/ISource.h"
 #include <string.h>
 
 
@@ -20,54 +21,25 @@ using namespace Kit::Framing;
 
 namespace {
 
-class MyUtt : public DecoderReader
+class MySrc : public ISource
 {
 public:
-    static constexpr size_t WORK_BUFFER_SIZE = 2;
-    uint8_t                 m_workBuffer[WORK_BUFFER_SIZE];
-    uint8_t                 m_sof;
-    uint8_t                 m_eof;
-    uint8_t                 m_escape;
-    uint8_t                 m_illegalByte;
-    const char*             m_inputSource;
-    size_t                  m_inputSourceLength;
-    size_t                  m_inputSourceIndex;
+    const char* m_inputSource;
+    size_t      m_inputSourceLength;
+    size_t      m_inputSourceIndex;
+    bool        m_resultRead;
+
 public:
-    MyUtt( const char* inputSource,
-           size_t      inputSourceLength,
-           char        startOfFrame = '.',
-           char        endOfFrame   = ';',
-           char        escape       = '~',
-           char        illegalByte  = '*' ) noexcept
-        : DecoderReader( m_workBuffer, WORK_BUFFER_SIZE )
-        , m_sof( startOfFrame )
-        , m_eof( endOfFrame )
-        , m_escape( escape )
-        , m_illegalByte( illegalByte )
-        , m_inputSource( inputSource )
+    MySrc( const char* inputSource,
+           size_t      inputSourceLength ) noexcept
+        : m_inputSource( inputSource )
         , m_inputSourceLength( inputSourceLength )
         , m_inputSourceIndex( 0 )
+        , m_resultRead( true )
     {
     }
 
 public:
-    bool isStartOfFrame( uint8_t byte ) noexcept override
-    {
-        return byte == m_sof;
-    }
-
-    bool isEndOfFrame( uint8_t byte ) noexcept override
-    {
-        return byte == m_eof;
-    }
-    bool isEscapeByte( uint8_t byte ) noexcept override
-    {
-        return byte == m_escape;
-    }
-    bool isLegalByte( uint8_t byte ) noexcept override
-    {
-        return byte != m_illegalByte;
-    }
     bool read( void*               dstBuffer,
                Kit::Type::SSize_T  numBytes,
                Kit::Type::SSize_T& bytesRead ) noexcept override
@@ -86,6 +58,46 @@ public:
     }
 };
 
+class MyUtt : public DecoderReader
+{
+public:
+    static constexpr size_t WORK_BUFFER_SIZE = 2;
+    uint8_t                 m_workBuffer[WORK_BUFFER_SIZE];
+    uint8_t                 m_sof;
+    uint8_t                 m_eof;
+    uint8_t                 m_escape;
+    uint8_t                 m_illegalByte;
+public:
+    MyUtt( ISource& inputSource, char startOfFrame, char endOfFrame, char escape, char illegalByte ) noexcept
+        : DecoderReader( inputSource, m_workBuffer, WORK_BUFFER_SIZE )
+        , m_sof( startOfFrame )
+        , m_eof( endOfFrame )
+        , m_escape( escape )
+        , m_illegalByte( illegalByte )
+    {
+    }
+
+    bool isStartOfFrame( uint8_t byte ) noexcept override
+    {
+        return byte == m_sof;
+    }
+
+    bool isEndOfFrame( uint8_t byte ) noexcept override
+    {
+        return byte == m_eof;
+    }
+
+    bool isEscapeByte( uint8_t byte ) noexcept override
+    {
+        return byte == m_escape;
+    }
+
+    bool isLegalByte( uint8_t byte ) noexcept override
+    {
+        return byte != m_illegalByte;
+    }
+};
+
 }  // end anonymous namespace
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -98,7 +110,8 @@ TEST_CASE( "DecoderReader" )
 
     SECTION( "Decode1" )
     {
-        MyUtt uut( ".abcde;", 7 );
+        MySrc src( ".abcde;", 7 );
+        MyUtt uut( src, '.', ';', '~', '*' );
         bool  result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
         REQUIRE( result == true );
         REQUIRE( strncmp( (char*)frameBuffer, "abcde", frameSize ) == 0 );
@@ -106,7 +119,8 @@ TEST_CASE( "DecoderReader" )
 
     SECTION( "Decode2" )
     {
-        MyUtt uut( ".a;b.c;", 7 );
+        MySrc src( ".a;b.c;", 7 );
+        MyUtt uut( src, '.', ';', '~', '*' );
         bool  result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
         REQUIRE( result == true );
         REQUIRE( strncmp( (char*)frameBuffer, "ac", frameSize ) == 0 );
@@ -117,7 +131,8 @@ TEST_CASE( "DecoderReader" )
 
     SECTION( "Decode3" )
     {
-        MyUtt uut( ".a~;bcd;", 8 );
+        MySrc src( ".a~;bcd;", 8 );
+        MyUtt uut( src, '.', ';', '~', '*' );
         bool  result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
         REQUIRE( result == true );
         REQUIRE( strncmp( (char*)frameBuffer, "a;bcd", frameSize ) == 0 );
@@ -125,7 +140,8 @@ TEST_CASE( "DecoderReader" )
 
     SECTION( "Decode4" )
     {
-        MyUtt uut( ".~~;", 4 );
+        MySrc src( ".~~;", 4 );
+        MyUtt uut( src, '.', ';', '~', '*' );
         bool  result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
         REQUIRE( result == true );
         REQUIRE( strncmp( (char*)frameBuffer, "~", frameSize ) == 0 );
@@ -133,7 +149,8 @@ TEST_CASE( "DecoderReader" )
 
     SECTION( "Decode5" )
     {
-        MyUtt uut( ".a~.bcd;", 8 );
+        MySrc src( ".a~.bcd;", 8 );
+        MyUtt uut( src, '.', ';', '~', '*' );
         bool  result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
         REQUIRE( result == true );
         REQUIRE( strncmp( (char*)frameBuffer, "a.bcd", frameSize ) == 0 );
@@ -141,7 +158,8 @@ TEST_CASE( "DecoderReader" )
 
     SECTION( "Decode6" )
     {
-        MyUtt uut( "cd~.abx;", 8 );
+        MySrc src( "cd~.abx;", 8 );
+        MyUtt uut( src, '.', ';', '~', '*' );
         bool  result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
         REQUIRE( result == true );
         REQUIRE( strncmp( (char*)frameBuffer, "abx", frameSize ) == 0 );
@@ -149,9 +167,19 @@ TEST_CASE( "DecoderReader" )
         REQUIRE( result == false );
     }
 
+    SECTION( "Decode7" )
+    {
+        MySrc src( ".a.~;bcd;", 9 );
+        MyUtt uut( src, '.', ';', '~', '*' );
+        bool  result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
+        REQUIRE( result == true );
+        REQUIRE( strncmp( (char*)frameBuffer, ";bcd", frameSize ) == 0 );
+    }
+
     SECTION( "oobRead1" )
     {
-        MyUtt              uut( "abcde", 5 );
+        MySrc              src( "abcde", 5 );
+        MyUtt              uut( src, '.', ';', '~', '*' );
         uint8_t            readBuffer[10];
         Kit::Type::SSize_T bytesRead;
         bool               result = uut.oobRead( readBuffer, sizeof( readBuffer ), bytesRead );
@@ -170,7 +198,8 @@ TEST_CASE( "DecoderReader" )
 
     SECTION( "oobRead2" )
     {
-        MyUtt uut( "a.bcd;hi.bob;", 13 );
+        MySrc src( "a.bcd;hi.bob;", 13 );
+        MyUtt uut( src, '.', ';', '~', '*' );
         bool  result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
         REQUIRE( result == true );
         REQUIRE( strncmp( (char*)frameBuffer, "bcd", frameSize ) == 0 );
@@ -189,7 +218,8 @@ TEST_CASE( "DecoderReader" )
 
     SECTION( "oobRead3" )
     {
-        MyUtt              uut( "abc", 3 );
+        MySrc              src( "abc", 3 );
+        MyUtt              uut( src, '.', ';', '~', '*' );
         uint8_t            readBuffer[1];
         Kit::Type::SSize_T bytesRead;
         bool               result = uut.oobRead( readBuffer, sizeof( readBuffer ), bytesRead );
@@ -210,7 +240,8 @@ TEST_CASE( "DecoderReader" )
 
     SECTION( "IllegalByte" )
     {
-        MyUtt uut( ".a*b;.good;", 11 );
+        MySrc src( ".a*b;.good;", 11 );
+        MyUtt uut( src, '.', ';', '~', '*' );
         bool  result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
         REQUIRE( result == true );
         REQUIRE( strncmp( (char*)frameBuffer, "good", frameSize ) == 0 );
@@ -218,7 +249,8 @@ TEST_CASE( "DecoderReader" )
 
     SECTION( "error1" )
     {
-        MyUtt uut( "aab;", 4 );
+        MySrc src( "aab;", 4 );
+        MyUtt uut( src, '.', ';', '~', '*' );
         bool  result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
         REQUIRE( result == false );
         result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
@@ -227,7 +259,8 @@ TEST_CASE( "DecoderReader" )
 
     SECTION( "error2" )
     {
-        MyUtt uut( ".ab~;a", 6 );
+        MySrc src( ".ab~;a", 6 );
+        MyUtt uut( src, '.', ';', '~', '*' );
         bool  result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
         REQUIRE( result == false );
         result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
@@ -236,7 +269,8 @@ TEST_CASE( "DecoderReader" )
 
     SECTION( "error3" )
     {
-        MyUtt uut( ".very log string that exceeds the framebuffer;", 46 );
+        MySrc src( ".very log string that exceeds the framebuffer;", 46 );
+        MyUtt uut( src, '.', ';', '~', '*' );
         bool  result = uut.scan( MAX_FRAME_SIZE, nullptr, frameSize );
         REQUIRE( result == false );
         result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );

--- a/src/Kit/Framing/_0test/decoderreader.cpp
+++ b/src/Kit/Framing/_0test/decoderreader.cpp
@@ -10,224 +10,237 @@
 
 #include "Kit/System/_testsupport/ShutdownUnitTesting.h"
 #include "catch2/catch_test_macros.hpp"
-#include "Kit/Text/BString.h"
+#include "Kit/Framing/DecoderReader.h"
 #include <string.h>
 
 
 ///
-using namespace Kit::Text;
 using namespace Kit::System;
+using namespace Kit::Framing;
 
+namespace {
 
+class MyUtt : public DecoderReader
+{
+public:
+    static constexpr size_t WORK_BUFFER_SIZE = 2;
+    uint8_t                 m_workBuffer[WORK_BUFFER_SIZE];
+    uint8_t                 m_sof;
+    uint8_t                 m_eof;
+    uint8_t                 m_escape;
+    uint8_t                 m_illegalByte;
+    const char*             m_inputSource;
+    size_t                  m_inputSourceLength;
+    size_t                  m_inputSourceIndex;
+public:
+    MyUtt( const char* inputSource,
+           size_t      inputSourceLength,
+           char        startOfFrame = '.',
+           char        endOfFrame   = ';',
+           char        escape       = '~',
+           char        illegalByte  = '*' ) noexcept
+        : DecoderReader( m_workBuffer, WORK_BUFFER_SIZE )
+        , m_sof( startOfFrame )
+        , m_eof( endOfFrame )
+        , m_escape( escape )
+        , m_illegalByte( illegalByte )
+        , m_inputSource( inputSource )
+        , m_inputSourceLength( inputSourceLength )
+        , m_inputSourceIndex( 0 )
+    {
+    }
+
+public:
+    bool isStartOfFrame( uint8_t byte ) noexcept override
+    {
+        return byte == m_sof;
+    }
+
+    bool isEndOfFrame( uint8_t byte ) noexcept override
+    {
+        return byte == m_eof;
+    }
+    bool isEscapeByte( uint8_t byte ) noexcept override
+    {
+        return byte == m_escape;
+    }
+    bool isLegalByte( uint8_t byte ) noexcept override
+    {
+        return byte != m_illegalByte;
+    }
+    bool read( void*               dstBuffer,
+               Kit::Type::SSize_T  numBytes,
+               Kit::Type::SSize_T& bytesRead ) noexcept override
+    {
+        if ( m_inputSourceIndex >= m_inputSourceLength )
+        {
+            bytesRead = 0;
+            return false;
+        }
+
+        size_t bytesToRead = std::min( static_cast<size_t>( numBytes ), m_inputSourceLength - m_inputSourceIndex );
+        memcpy( dstBuffer, m_inputSource + m_inputSourceIndex, bytesToRead );
+        m_inputSourceIndex += bytesToRead;
+        bytesRead           = bytesToRead;
+        return true;
+    }
+};
+
+}  // end anonymous namespace
 ////////////////////////////////////////////////////////////////////////////////
-TEST_CASE( "BString" )
+
+TEST_CASE( "DecoderReader" )
 {
     ShutdownUnitTesting::clearAndUseCounter();
-    char     rawMemory0[11];
-    char     rawMemory1[6];
-    BString  foo( rawMemory0, sizeof( rawMemory0 ), "Hello World, this is bob" );
-    BString  bar( rawMemory1, sizeof( rawMemory1 ), "Hello World, this is bob" );
-    IString& bref = bar;
+    static constexpr size_t MAX_FRAME_SIZE = 12;
+    uint8_t                 frameBuffer[MAX_FRAME_SIZE];
+    Kit::Type::SSize_T      frameSize;
 
-
-    SECTION( "Some basic operation" )
+    SECTION( "Decode1" )
     {
-        REQUIRE( foo != bar );
-        REQUIRE( bar == bref );
-
-        /* 0123456789 */
-        foo.insertAt( 0, "HI" );
-        REQUIRE( foo == "HIHello Wo" );
-        foo.insertAt( -1, "HI" );
-        REQUIRE( foo == "HIHIHello " );
-        foo.insertAt( 9, "HI" );
-        REQUIRE( foo == "HIHIHelloH" );
-        foo.insertAt( 10, "!!" );
-        REQUIRE( foo == "HIHIHelloH" );
-        foo.insertAt( 5, "<*>" );
-        REQUIRE( foo == "HIHIH<*>el" );
-        foo = "123";
-        foo.insertAt( 10, "Bob's here" );
-        REQUIRE( foo == "123Bob's h" );
-        foo = "456";
-        foo.insertAt( 1, "Uncle" );
-        REQUIRE( foo == "4Uncle56" );
+        MyUtt uut( ".abcde;", 7 );
+        bool  result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
+        REQUIRE( result == true );
+        REQUIRE( strncmp( (char*)frameBuffer, "abcde", frameSize ) == 0 );
     }
 
-    SECTION( "Constructors" )
+    SECTION( "Decode2" )
     {
-        const char* nullPtr = 0;
-        char        rawMemory2[4];
-        BString     s0( rawMemory2, sizeof( rawMemory2 ), nullPtr );
-        REQUIRE( s0 == "" );
-
-        char    rawMemory3[4];
-        BString s1( rawMemory3, sizeof( rawMemory3 ) );
-        REQUIRE( s1 == "" );
-
-        s1 = "uncle";
-        char    rawMemory4[4];
-        BString s2( rawMemory4, sizeof( rawMemory4 ), s1 );
-        REQUIRE( s2 == "unc" );
-
-        char    rawMemory5[4];
-        BString s3( rawMemory5, sizeof( rawMemory5 ), bref );
-        REQUIRE( s3 == "Hel" );
-
-        char    rawMemory6[4];
-        BString s4( rawMemory6, sizeof( rawMemory6 ), "abcdefghijklmnopqrstuvwxyz" );
-        REQUIRE( s4 == "abc" );
-
-        char    rawMemory7[4];
-        BString s5( rawMemory7, sizeof( rawMemory7 ), '@' );
-        REQUIRE( s5 == '@' );
-
-        char    rawMemory8[4];
-        BString s6( rawMemory8, sizeof( rawMemory8 ), -32 );
-        REQUIRE( s6 == "-32" );
-
-        char    rawMemory9[4];
-        BString s7( rawMemory9, sizeof( rawMemory9 ), (unsigned)42 );
-        REQUIRE( s7 == "42" );
-
-        char    rawMemory10[4];
-        BString s8( rawMemory10, sizeof( rawMemory10 ), (long)-10000000 );
-        REQUIRE( s8 == "-10" );
-
-
-        char    rawMemory11[4];
-        BString s9( rawMemory11, sizeof( rawMemory11 ), (unsigned long)81000000 );
-        REQUIRE( s9 == "810" );
-
-        char    rawMemory12[4];
-        BString s10( rawMemory12, sizeof( rawMemory12 ), (long long)-200000000000 );
-        REQUIRE( s10 == "-20" );
-
-
-        char    rawMemory13[4];
-        BString s11( rawMemory13, sizeof( rawMemory13 ), (unsigned long long)9100000000000 );
-        REQUIRE( s11 == "910" );
-
-        char    rawMemory14[2];
-        BString s12( rawMemory14, 0, "hello" );
-        REQUIRE( s12 == "" );
-
-        char    rawMemory15[6];
-        BString s13( rawMemory15, 1, "hello" );
-        REQUIRE( s13 == "" );
-
-        BString s14( nullptr, 2, "hello" );
-        REQUIRE( s14 == "" );
+        MyUtt uut( ".a;b.c;", 7 );
+        bool  result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
+        REQUIRE( result == true );
+        REQUIRE( strncmp( (char*)frameBuffer, "ac", frameSize ) == 0 );
+        result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
+        REQUIRE( result == true );
+        REQUIRE( strncmp( (char*)frameBuffer, "c", frameSize ) == 0 );
     }
 
-    SECTION( "Assignments" )
+    SECTION( "Decode3" )
     {
-        const char* nullPtr = 0;
-        char        rawMemory2[4];
-        BString     s0( rawMemory2, sizeof( rawMemory2 ), "****" );
-        s0 = nullPtr;
-        REQUIRE( s0 == "" );
-
-        char    rawMemory3[4];
-        BString s1( rawMemory3, sizeof( rawMemory3 ), "****" );
-        s1 = "";
-        REQUIRE( s1 == "" );
-
-        s1 = "uncle";
-        char    rawMemory4[4];
-        BString s2( rawMemory4, sizeof( rawMemory4 ), "****" );
-        s2 = s1;
-        REQUIRE( s2 == "unc" );
-
-        char    rawMemory5[4];
-        BString s3( rawMemory5, sizeof( rawMemory5 ), "****" );
-        s3 = bref;
-        REQUIRE( s3 == "Hel" );
-
-        char    rawMemory6[4];
-        BString s4( rawMemory6, sizeof( rawMemory6 ), "****" );
-        s4 = "abcdefghijklmnopqrstuvwxyz";
-        REQUIRE( s4 == "abc" );
-
-        char    rawMemory7[4];
-        BString s5( rawMemory7, sizeof( rawMemory7 ), "****" );
-        s5 = '@';
-        REQUIRE( s5 == '@' );
-
-        char    rawMemory8[4];
-        BString s6( rawMemory8, sizeof( rawMemory8 ), "****" );
-        s6 = -32;
-        REQUIRE( s6 == "-32" );
-
-        char    rawMemory9[4];
-        BString s7( rawMemory9, sizeof( rawMemory9 ), "****" );
-        s7 = (unsigned)42;
-        REQUIRE( s7 == "42" );
-
-        char    rawMemory10[4];
-        BString s8( rawMemory10, sizeof( rawMemory10 ), "****" );
-        s8 = (long)-10000000;
-        REQUIRE( s8 == "-10" );
-
-        char    rawMemory11[4];
-        BString s9( rawMemory11, sizeof( rawMemory11 ), "****" );
-        s9 = (unsigned long)81000000;
-        REQUIRE( s9 == "810" );
+        MyUtt uut( ".a~;bcd;", 8 );
+        bool  result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
+        REQUIRE( result == true );
+        REQUIRE( strncmp( (char*)frameBuffer, "a;bcd", frameSize ) == 0 );
     }
 
-    SECTION( "Append" )
+    SECTION( "Decode4" )
     {
-        const char* nullPtr = 0;
-        char        rawMemory2[9];
-        BString     s0( rawMemory2, sizeof( rawMemory2 ), "****" );
-        s0 += nullPtr;
-        REQUIRE( s0 == "****" );
+        MyUtt uut( ".~~;", 4 );
+        bool  result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
+        REQUIRE( result == true );
+        REQUIRE( strncmp( (char*)frameBuffer, "~", frameSize ) == 0 );
+    }
 
-        char    rawMemory3[9];
-        BString s1( rawMemory3, sizeof( rawMemory3 ), "****" );
-        s1 += "";
-        REQUIRE( s1 == "****" );
+    SECTION( "Decode5" )
+    {
+        MyUtt uut( ".a~.bcd;", 8 );
+        bool  result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
+        REQUIRE( result == true );
+        REQUIRE( strncmp( (char*)frameBuffer, "a.bcd", frameSize ) == 0 );
+    }
 
-        s1 = "uncle";
-        char    rawMemory4[9];
-        BString s2( rawMemory4, sizeof( rawMemory4 ), "****" );
-        s2 += s1;
-        REQUIRE( s2 == "****uncl" );
+    SECTION( "Decode6" )
+    {
+        MyUtt uut( "cd~.abx;", 8 );
+        bool  result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
+        REQUIRE( result == true );
+        REQUIRE( strncmp( (char*)frameBuffer, "abx", frameSize ) == 0 );
+        result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
+        REQUIRE( result == false );
+    }
 
-        char    rawMemory5[9];
-        BString s3( rawMemory5, sizeof( rawMemory5 ), "****" );
-        s3 += bref;
-        REQUIRE( s3 == "****Hell" );
+    SECTION( "oobRead1" )
+    {
+        MyUtt              uut( "abcde", 5 );
+        uint8_t            readBuffer[10];
+        Kit::Type::SSize_T bytesRead;
+        bool               result = uut.oobRead( readBuffer, sizeof( readBuffer ), bytesRead );
+        REQUIRE( result == true );
+        REQUIRE( bytesRead == 2 );
+        REQUIRE( strncmp( (char*)readBuffer, "ab", bytesRead ) == 0 );
+        result = uut.oobRead( readBuffer, sizeof( readBuffer ), bytesRead );
+        REQUIRE( result == true );
+        REQUIRE( bytesRead == 2 );
+        REQUIRE( strncmp( (char*)readBuffer, "cd", bytesRead ) == 0 );
+        result = uut.oobRead( readBuffer, sizeof( readBuffer ), bytesRead );
+        REQUIRE( result == true );
+        REQUIRE( bytesRead == 1 );
+        REQUIRE( strncmp( (char*)readBuffer, "e", bytesRead ) == 0 );
+    }
 
-        char    rawMemory6[9];
-        BString s4( rawMemory6, sizeof( rawMemory6 ), "****" );
-        s4 += "abcdefghijklmnopqrstuvwxyz";
-        REQUIRE( s4 == "****abcd" );
+    SECTION( "oobRead2" )
+    {
+        MyUtt uut( "a.bcd;hi.bob;", 13 );
+        bool  result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
+        REQUIRE( result == true );
+        REQUIRE( strncmp( (char*)frameBuffer, "bcd", frameSize ) == 0 );
 
-        char    rawMemory7[9];
-        BString s5( rawMemory7, sizeof( rawMemory7 ), "****" );
-        s5 += '@';
-        REQUIRE( s5 == "****@" );
+        uint8_t            readBuffer[10];
+        Kit::Type::SSize_T bytesRead;
+        result = uut.oobRead( readBuffer, sizeof( readBuffer ), bytesRead );
+        REQUIRE( result == true );
+        REQUIRE( bytesRead == 2 );
+        REQUIRE( strncmp( (char*)readBuffer, "hi", bytesRead ) == 0 );
 
-        char    rawMemory8[9];
-        BString s6( rawMemory8, sizeof( rawMemory8 ), "****" );
-        s6 += -32;
-        REQUIRE( s6 == "****-32" );
+        result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
+        REQUIRE( result == true );
+        REQUIRE( strncmp( (char*)frameBuffer, "bob", frameSize ) == 0 );
+    }
 
-        char    rawMemory9[9];
-        BString s7( rawMemory9, sizeof( rawMemory9 ), "****" );
-        s7 += (unsigned)42;
-        REQUIRE( s7 == "****42" );
+    SECTION( "oobRead3" )
+    {
+        MyUtt              uut( "abc", 3 );
+        uint8_t            readBuffer[1];
+        Kit::Type::SSize_T bytesRead;
+        bool               result = uut.oobRead( readBuffer, sizeof( readBuffer ), bytesRead );
+        REQUIRE( result == true );
+        REQUIRE( bytesRead == 1 );
+        REQUIRE( strncmp( (char*)readBuffer, "a", bytesRead ) == 0 );
+        result = uut.oobRead( readBuffer, sizeof( readBuffer ), bytesRead );
+        REQUIRE( result == true );
+        REQUIRE( bytesRead == 1 );
+        REQUIRE( strncmp( (char*)readBuffer, "b", bytesRead ) == 0 );
+        result = uut.oobRead( readBuffer, sizeof( readBuffer ), bytesRead );
+        REQUIRE( result == true );
+        REQUIRE( bytesRead == 1 );
+        REQUIRE( strncmp( (char*)readBuffer, "c", bytesRead ) == 0 );
+        result = uut.oobRead( readBuffer, sizeof( readBuffer ), bytesRead );
+        REQUIRE( result == false );
+    }
 
-        char    rawMemory10[9];
-        BString s8( rawMemory10, sizeof( rawMemory10 ), "****" );
-        s8 += (long)-10000000;
-        REQUIRE( s8 == "****-100" );
+    SECTION( "IllegalByte" )
+    {
+        MyUtt uut( ".a*b;.good;", 11 );
+        bool  result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
+        REQUIRE( result == true );
+        REQUIRE( strncmp( (char*)frameBuffer, "good", frameSize ) == 0 );
+    }
 
-        char    rawMemory11[9];
-        BString s9( rawMemory11, sizeof( rawMemory11 ), "****" );
-        s9 += (unsigned long)81000000;
-        REQUIRE( s9 == "****8100" );
+    SECTION( "error1" )
+    {
+        MyUtt uut( "aab;", 4 );
+        bool  result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
+        REQUIRE( result == false );
+        result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
+        REQUIRE( result == false );
+    }
+
+    SECTION( "error2" )
+    {
+        MyUtt uut( ".ab~;a", 6 );
+        bool  result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
+        REQUIRE( result == false );
+        result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
+        REQUIRE( result == false );
+    }
+
+    SECTION( "error3" )
+    {
+        MyUtt uut( ".very log string that exceeds the framebuffer;", 46 );
+        bool  result = uut.scan( MAX_FRAME_SIZE, nullptr, frameSize );
+        REQUIRE( result == false );
+        result = uut.scan( MAX_FRAME_SIZE, frameBuffer, frameSize );
+        REQUIRE( result == false );
     }
 
     REQUIRE( ShutdownUnitTesting::getAndClearCounter() == 0u );

--- a/src/Kit/Framing/_0test/encoderwriter.cpp
+++ b/src/Kit/Framing/_0test/encoderwriter.cpp
@@ -22,7 +22,7 @@ using namespace Kit::Framing;
 
 namespace {
 
-class MyUtt : public EncoderWriter
+class MyDestination : public IDestination
 {
 public:
     char   m_outputBuffer[100];
@@ -32,20 +32,13 @@ public:
     bool   m_resultAppendOutput;
     bool   m_resultEndOutput;
 public:
-    MyUtt( char startOfFrame, char endOfFrame, char escapeByte, bool skipSendingSof = false ) noexcept
-        : EncoderWriter( startOfFrame, endOfFrame, escapeByte, skipSendingSof )
-        , m_bytesWritten( 0 )
+    MyDestination() noexcept
+        : m_bytesWritten( 0 )
         , m_nextByteIndex( 0 )
         , m_resultStartOutput( true )
         , m_resultAppendOutput( true )
         , m_resultEndOutput( true )
     {
-    }
-
-public:
-    bool outputString( const char* srcString )
-    {
-        return output( srcString, strlen( srcString ) );
     }
 
 protected:
@@ -55,12 +48,17 @@ protected:
         return m_resultStartOutput;
     }
 
-    bool appendOutput( uint8_t srcByte ) noexcept
+    bool appendOutput( const void* srcBuffer, Kit::Type::SSize_T numBytes ) noexcept
     {
-        m_outputBuffer[m_nextByteIndex] = srcByte;
-        m_nextByteIndex++;
+        const uint8_t* buffer = static_cast<const uint8_t*>(srcBuffer);
+        for ( Kit::Type::SSize_T i = 0; i < numBytes; ++i )
+        {
+            m_outputBuffer[m_nextByteIndex] = buffer[i];
+            m_nextByteIndex++;
+        }
         return m_resultAppendOutput;
     }
+
     bool endOutput() noexcept
     {
         m_outputBuffer[m_nextByteIndex] = '\0';
@@ -72,79 +70,90 @@ protected:
 }  // end anonymous namespace
 ////////////////////////////////////////////////////////////////////////////////
 
+#define OUTPUT_STRING( str ) uut.output( str , strlen( str ) )
+
 TEST_CASE( "EncoderWriter" )
 {
     ShutdownUnitTesting::clearAndUseCounter();
-    MyUtt uut( '.', ';', '~' );
+    MyDestination dst;
+    EncoderWriter uut( dst, '.', ';', '~' );
 
     SECTION( "Encode" )
     {
         uut.startFrame();
-        uut.outputString( "abcd" );
+        OUTPUT_STRING( "abcd" );
         uut.endFrame();
-        REQUIRE( strcmp( uut.m_outputBuffer, ".abcd;" ) == 0 );
+        REQUIRE( strcmp( dst.m_outputBuffer, ".abcd;" ) == 0 );
 
         uut.startFrame();
-        uut.outputString( "a");
+        OUTPUT_STRING( "a");
         uut.endFrame();
-        REQUIRE( strcmp( uut.m_outputBuffer, ".a;" ) == 0 );
+        REQUIRE( strcmp( dst.m_outputBuffer, ".a;" ) == 0 );
 
         uut.startFrame();
-        uut.outputString( "b");
+        OUTPUT_STRING( "b");
         uut.endFrame();
-        REQUIRE( strcmp( uut.m_outputBuffer, ".b;" ) == 0 );
+        REQUIRE( strcmp( dst.m_outputBuffer, ".b;" ) == 0 );
 
         uut.startFrame();
         uut.endFrame();
-        REQUIRE( strcmp( uut.m_outputBuffer, ".;" ) == 0 );
+        REQUIRE( strcmp( dst.m_outputBuffer, ".;" ) == 0 );
 
         uut.startFrame();
-        uut.outputString( "a;bcd");
+        OUTPUT_STRING( "a;bcd");
         uut.endFrame();
-        REQUIRE( strcmp( uut.m_outputBuffer, ".a~;bcd;" ) == 0 );
+        REQUIRE( strcmp( dst.m_outputBuffer, ".a~;bcd;" ) == 0 );
 
         uut.startFrame();
-        uut.outputString( "~" );
+        OUTPUT_STRING( "~" );
         uut.endFrame();
-        REQUIRE( strcmp( uut.m_outputBuffer, ".~~;" ) == 0 );
+        REQUIRE( strcmp( dst.m_outputBuffer, ".~~;" ) == 0 );
 
         uut.startFrame();
-        uut.outputString( "a.bcd" );
+        OUTPUT_STRING( "a.bcd" );
         uut.endFrame();
-        REQUIRE( strcmp( uut.m_outputBuffer, ".a~.bcd;" ) == 0 );
+        REQUIRE( strcmp( dst.m_outputBuffer, ".a~.bcd;" ) == 0 );
     }
 
     SECTION( "errors")
     {
         uut.startFrame();
-        uut.outputString( "abc");
+        OUTPUT_STRING( "abc");
         uut.startFrame();
-        uut.outputString( "ZYX");
+        OUTPUT_STRING( "ZYX");
         uut.endFrame();
-        REQUIRE( strcmp( uut.m_outputBuffer, ".ZYX;" ) == 0 );
+        REQUIRE( strcmp( dst.m_outputBuffer, ".ZYX;" ) == 0 );
 
         uut.startFrame();
-        REQUIRE( uut.outputString( "abc") == true );
-        uut.m_resultAppendOutput = false;
-        REQUIRE( uut.outputString( "def") == false );
+        REQUIRE( OUTPUT_STRING( "abc") == true );
+        dst.m_resultAppendOutput = false;
+        REQUIRE( OUTPUT_STRING( "def") == false );
         REQUIRE( uut.endFrame() == false );
 
-        uut.m_resultAppendOutput = true;
+        dst.m_resultAppendOutput = true;
         uut.startFrame();
-        REQUIRE( uut.outputString( "abc") == true );
-        uut.m_resultEndOutput = false;
+        REQUIRE( OUTPUT_STRING( "abc") == true );
+        dst.m_resultEndOutput = false;
         REQUIRE( uut.endFrame() == false );
 
-        uut.m_resultEndOutput = true;
+        dst.m_resultEndOutput = true;
         uut.startFrame();
-        uut.outputString( "a.bcd" );
-        uut.m_resultAppendOutput = false;
+        OUTPUT_STRING( "a.bcd" );
+        dst.m_resultAppendOutput = false;
         REQUIRE( uut.endFrame() == false );
 
-        uut.m_resultAppendOutput = true;
+        dst.m_resultAppendOutput = true;
         uut.startFrame();
-        uut.m_resultEndOutput = false;
+        dst.m_resultEndOutput = false;
         REQUIRE( uut.startFrame() == false );
+
+        dst.m_resultEndOutput = true;
+        REQUIRE( uut.startFrame() );
+        REQUIRE( uut.output( nullptr, 5 ) == false );
+        REQUIRE( uut.output( "abc", -1 ) == false );
+        REQUIRE( uut.output( "abc", 0 ) == true );
+        REQUIRE( uut.endFrame() == true );
+        REQUIRE( strcmp( dst.m_outputBuffer, ".;" ) == 0 );
     }
 
     REQUIRE( ShutdownUnitTesting::getAndClearCounter() == 0u );

--- a/src/Kit/Framing/_0test/encoderwriter.cpp
+++ b/src/Kit/Framing/_0test/encoderwriter.cpp
@@ -1,0 +1,151 @@
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/System/_testsupport/ShutdownUnitTesting.h"
+#include "catch2/catch_test_macros.hpp"
+#include "Kit/Framing/EncoderWriter.h"
+#include "Kit/System/Trace.h"
+#include <string.h>
+
+#define SECT_ "_0test"
+
+///
+using namespace Kit::System;
+using namespace Kit::Framing;
+
+namespace {
+
+class MyUtt : public EncoderWriter
+{
+public:
+    char   m_outputBuffer[100];
+    size_t m_bytesWritten;
+    size_t m_nextByteIndex;
+    bool   m_resultStartOutput;
+    bool   m_resultAppendOutput;
+    bool   m_resultEndOutput;
+public:
+    MyUtt( char startOfFrame, char endOfFrame, char escapeByte, bool skipSendingSof = false ) noexcept
+        : EncoderWriter( startOfFrame, endOfFrame, escapeByte, skipSendingSof )
+        , m_bytesWritten( 0 )
+        , m_nextByteIndex( 0 )
+        , m_resultStartOutput( true )
+        , m_resultAppendOutput( true )
+        , m_resultEndOutput( true )
+    {
+    }
+
+public:
+    bool outputString( const char* srcString )
+    {
+        return output( srcString, strlen( srcString ) );
+    }
+
+protected:
+    bool startOutput() noexcept
+    {
+        m_nextByteIndex = 0;
+        return m_resultStartOutput;
+    }
+
+    bool appendOutput( uint8_t srcByte ) noexcept
+    {
+        m_outputBuffer[m_nextByteIndex] = srcByte;
+        m_nextByteIndex++;
+        return m_resultAppendOutput;
+    }
+    bool endOutput() noexcept
+    {
+        m_outputBuffer[m_nextByteIndex] = '\0';
+        KIT_SYSTEM_TRACE_MSG( SECT_, "FRAME: [%s]", m_outputBuffer );
+        return m_resultEndOutput;
+    }
+};
+
+}  // end anonymous namespace
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_CASE( "EncoderWriter" )
+{
+    ShutdownUnitTesting::clearAndUseCounter();
+    MyUtt uut( '.', ';', '~' );
+
+    SECTION( "Encode" )
+    {
+        uut.startFrame();
+        uut.outputString( "abcd" );
+        uut.endFrame();
+        REQUIRE( strcmp( uut.m_outputBuffer, ".abcd;" ) == 0 );
+
+        uut.startFrame();
+        uut.outputString( "a");
+        uut.endFrame();
+        REQUIRE( strcmp( uut.m_outputBuffer, ".a;" ) == 0 );
+
+        uut.startFrame();
+        uut.outputString( "b");
+        uut.endFrame();
+        REQUIRE( strcmp( uut.m_outputBuffer, ".b;" ) == 0 );
+
+        uut.startFrame();
+        uut.endFrame();
+        REQUIRE( strcmp( uut.m_outputBuffer, ".;" ) == 0 );
+
+        uut.startFrame();
+        uut.outputString( "a;bcd");
+        uut.endFrame();
+        REQUIRE( strcmp( uut.m_outputBuffer, ".a~;bcd;" ) == 0 );
+
+        uut.startFrame();
+        uut.outputString( "~" );
+        uut.endFrame();
+        REQUIRE( strcmp( uut.m_outputBuffer, ".~~;" ) == 0 );
+
+        uut.startFrame();
+        uut.outputString( "a.bcd" );
+        uut.endFrame();
+        REQUIRE( strcmp( uut.m_outputBuffer, ".a~.bcd;" ) == 0 );
+    }
+
+    SECTION( "errors")
+    {
+        uut.startFrame();
+        uut.outputString( "abc");
+        uut.startFrame();
+        uut.outputString( "ZYX");
+        uut.endFrame();
+        REQUIRE( strcmp( uut.m_outputBuffer, ".ZYX;" ) == 0 );
+
+        uut.startFrame();
+        REQUIRE( uut.outputString( "abc") == true );
+        uut.m_resultAppendOutput = false;
+        REQUIRE( uut.outputString( "def") == false );
+        REQUIRE( uut.endFrame() == false );
+
+        uut.m_resultAppendOutput = true;
+        uut.startFrame();
+        REQUIRE( uut.outputString( "abc") == true );
+        uut.m_resultEndOutput = false;
+        REQUIRE( uut.endFrame() == false );
+
+        uut.m_resultEndOutput = true;
+        uut.startFrame();
+        uut.outputString( "a.bcd" );
+        uut.m_resultAppendOutput = false;
+        REQUIRE( uut.endFrame() == false );
+
+        uut.m_resultAppendOutput = true;
+        uut.startFrame();
+        uut.m_resultEndOutput = false;
+        REQUIRE( uut.startFrame() == false );
+    }
+
+    REQUIRE( ShutdownUnitTesting::getAndClearCounter() == 0u );
+}

--- a/src/Kit/Framing/_0test/linedecoder.cpp
+++ b/src/Kit/Framing/_0test/linedecoder.cpp
@@ -1,0 +1,73 @@
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/System/_testsupport/ShutdownUnitTesting.h"
+#include "catch2/catch_test_macros.hpp"
+#include "Kit/Framing/StreamSource.h"
+#include "Kit/Io/Ram/InputOutputAllocate.h"
+#include "Kit/Framing/LineDecoderAllocate.h"
+#include "Kit/System/Trace.h"
+#include <string.h>
+
+#define SECT_ "_0test"
+
+///
+using namespace Kit::System;
+using namespace Kit::Framing;
+using namespace Kit::Type;
+
+#define TEST_FRAME         "Hello Kitty!"
+#define TEST_IN_TEXT       "Hello\tKitty!"
+#define TEST_OUT_FRAME     "Hello*Kitty!"
+#define TEST_NON_PRINTABLE "Hello\1Kitty!"
+
+////////////////////////////////////
+TEST_CASE( "LineDecoder" )
+{
+    ShutdownUnitTesting::clearAndUseCounter();
+    Kit::Io::Ram::InputOutputAllocate<64> src;  // Must be large enough to hold the test string TWICE
+    StreamSource                          decoderSrc( src );
+    constexpr SSize_T                     MAX_FRAME_SIZE = 64;
+    uint8_t                               frame[MAX_FRAME_SIZE];
+    SSize_T                               frameSize;
+
+    SECTION( "Nominal case" )
+    {
+        LineDecoderAllocate<4> uut( decoderSrc );
+        const char*            testString = TEST_FRAME "\n ";
+        src.write( testString );
+        REQUIRE( uut.scan( MAX_FRAME_SIZE, frame, frameSize ) == true );
+        REQUIRE( frameSize == (SSize_T)( strlen( TEST_FRAME ) ) );
+        REQUIRE( strcmp( (const char*)frame, TEST_FRAME ) == 0 );
+    }
+
+    SECTION( "Convert Tabs" )
+    {
+        LineDecoderAllocate<10> uut( decoderSrc, '*' );
+        const char*             testString = TEST_IN_TEXT "\n ";
+        src.write( testString );
+        REQUIRE( uut.scan( MAX_FRAME_SIZE, frame, frameSize ) == true );
+        REQUIRE( frameSize == (SSize_T)( strlen( TEST_OUT_FRAME ) ) );
+        REQUIRE( strcmp( (const char*)frame, TEST_OUT_FRAME ) == 0 );
+    }
+
+    SECTION( "non-printable" )
+    {
+        LineDecoderAllocate<10> uut( decoderSrc, '*' );
+        const char*             testString = TEST_NON_PRINTABLE "\n\b" TEST_FRAME "\n";
+        src.write( testString );
+        REQUIRE( uut.scan( MAX_FRAME_SIZE, frame, frameSize ) == true );
+        REQUIRE( frameSize == (SSize_T)( strlen( TEST_FRAME ) ) );
+        REQUIRE( strcmp( (const char*)frame, TEST_FRAME ) == 0 );
+    }
+
+    src.close();
+    REQUIRE( ShutdownUnitTesting::getAndClearCounter() == 0u );
+}

--- a/src/Kit/Framing/_0test/linedecoder.cpp
+++ b/src/Kit/Framing/_0test/linedecoder.cpp
@@ -45,7 +45,7 @@ TEST_CASE( "LineDecoder" )
         src.write( testString );
         REQUIRE( uut.scan( MAX_FRAME_SIZE, frame, frameSize ) == true );
         REQUIRE( frameSize == (SSize_T)( strlen( TEST_FRAME ) ) );
-        REQUIRE( strcmp( (const char*)frame, TEST_FRAME ) == 0 );
+        REQUIRE( strncmp( (const char*)frame, TEST_FRAME, strlen(TEST_FRAME) ) == 0 );
     }
 
     SECTION( "Convert Tabs" )
@@ -55,7 +55,7 @@ TEST_CASE( "LineDecoder" )
         src.write( testString );
         REQUIRE( uut.scan( MAX_FRAME_SIZE, frame, frameSize ) == true );
         REQUIRE( frameSize == (SSize_T)( strlen( TEST_OUT_FRAME ) ) );
-        REQUIRE( strcmp( (const char*)frame, TEST_OUT_FRAME ) == 0 );
+        REQUIRE( strncmp( (const char*)frame, TEST_OUT_FRAME, strlen(TEST_OUT_FRAME) ) == 0 );
     }
 
     SECTION( "non-printable" )
@@ -65,7 +65,7 @@ TEST_CASE( "LineDecoder" )
         src.write( testString );
         REQUIRE( uut.scan( MAX_FRAME_SIZE, frame, frameSize ) == true );
         REQUIRE( frameSize == (SSize_T)( strlen( TEST_FRAME ) ) );
-        REQUIRE( strcmp( (const char*)frame, TEST_FRAME ) == 0 );
+        REQUIRE( strncmp( (const char*)frame, TEST_FRAME, strlen(TEST_FRAME) ) == 0 );
     }
 
     src.close();

--- a/src/Kit/Framing/_0test/streamdestination.cpp
+++ b/src/Kit/Framing/_0test/streamdestination.cpp
@@ -1,0 +1,68 @@
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/System/_testsupport/ShutdownUnitTesting.h"
+#include "catch2/catch_test_macros.hpp"
+#include "Kit/Framing/StreamDestination.h"
+#include "Kit/Io/Ram/InputOutputAllocate.h"
+#include "Kit/System/Trace.h"
+#include <string.h>
+
+#define SECT_ "_0test"
+
+///
+using namespace Kit::System;
+using namespace Kit::Framing;
+
+
+////////////////////////////////////
+TEST_CASE( "StreamDestination" )
+{
+    ShutdownUnitTesting::clearAndUseCounter();
+    Kit::Io::Ram::InputOutputAllocate<20> dst;
+    StreamDestination                     uut( dst );
+    char                                  buffer[10];
+    Kit::Type::SSize_T                    bytesRead;
+
+    REQUIRE( uut.startOutput() == true );
+    REQUIRE( uut.appendOutput( "Hello", 5 ) == true );
+    REQUIRE( dst.available() == true );
+    REQUIRE( dst.read( buffer, 5, bytesRead ) == true );
+    REQUIRE( bytesRead == 5 );
+    REQUIRE( strncmp( buffer, "Hello", 5 ) == 0 );
+    REQUIRE( uut.endOutput() == true );
+
+    REQUIRE( uut.startOutput() == true );
+    REQUIRE( uut.appendOutput( "Kitty!", 6 ) == true );
+    REQUIRE( uut.appendOutput( nullptr, 6 ) == false );
+    REQUIRE( dst.available() == true );
+    REQUIRE( dst.read( buffer, 6, bytesRead ) == true );
+    REQUIRE( bytesRead == 6 );
+    REQUIRE( strncmp( buffer, "Kitty!", 6 ) == 0 );
+    REQUIRE( uut.endOutput() == true );
+
+    dst.close();
+    REQUIRE( uut.startOutput() == true );
+    REQUIRE( uut.appendOutput( "Kitty!", 6 ) == false );
+    REQUIRE( uut.endOutput() == true );
+
+    StreamDestination uut2;
+    REQUIRE( uut2.startOutput() == false );
+    REQUIRE( uut2.appendOutput( "Kitty!", 6 ) == false );
+    REQUIRE( uut2.endOutput() == false );
+
+    StreamDestination uut3;
+    uut3.setOutput( dst );
+    REQUIRE( uut3.startOutput() == true );
+    REQUIRE( uut3.appendOutput( "Kitty!", 6 ) == false );
+    REQUIRE( uut3.endOutput() == true );
+
+    REQUIRE( ShutdownUnitTesting::getAndClearCounter() == 0u );
+}

--- a/src/Kit/Framing/_0test/streamsource.cpp
+++ b/src/Kit/Framing/_0test/streamsource.cpp
@@ -26,12 +26,12 @@ using namespace Kit::Framing;
 TEST_CASE( "StreamSource" )
 {
     ShutdownUnitTesting::clearAndUseCounter();
-    Kit::Io::Ram::InputOutputAllocate<64> dst; // Must be large enough to hold the test string TWICE
-    StreamSource                          uut( dst );
+    Kit::Io::Ram::InputOutputAllocate<64> src; // Must be large enough to hold the test string TWICE
+    StreamSource                          uut( src );
     char                                  buffer[14];
     Kit::Type::SSize_T                    bytesRead;
 
-    dst.write( "Hello Kitty!" );
+    src.write( "Hello Kitty!" );
     REQUIRE( uut.read( buffer, 5, bytesRead ) == true );
     REQUIRE( bytesRead == 5 );
     REQUIRE( strncmp( buffer, "Hello", 5 ) == 0 );
@@ -47,8 +47,8 @@ TEST_CASE( "StreamSource" )
     memset( buffer, 0, sizeof( buffer ) );
     REQUIRE( uut2.read( buffer, 5, bytesRead ) == false );
     REQUIRE( bytesRead == 0 );
-    uut2.setInput( dst );
-    dst.write( "Hello Kitty!" );
+    uut2.setInput( src );
+    src.write( "Hello Kitty!" );
     REQUIRE( uut2.read( buffer, 5, bytesRead ) == true );
     REQUIRE( bytesRead == 5 );
     REQUIRE( strncmp( buffer, "Hello", 5 ) == 0 );
@@ -59,7 +59,7 @@ TEST_CASE( "StreamSource" )
     REQUIRE( uut2.read( buffer, sizeof( buffer ), bytesRead ) == false );
     REQUIRE( bytesRead == 0 );
 
-    dst.close();
+    src.close();
     REQUIRE( uut2.read( buffer, sizeof( buffer ), bytesRead ) == false );
 
     REQUIRE( ShutdownUnitTesting::getAndClearCounter() == 0u );

--- a/src/Kit/Framing/_0test/streamsource.cpp
+++ b/src/Kit/Framing/_0test/streamsource.cpp
@@ -1,0 +1,66 @@
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/System/_testsupport/ShutdownUnitTesting.h"
+#include "catch2/catch_test_macros.hpp"
+#include "Kit/Framing/StreamSource.h"
+#include "Kit/Io/Ram/InputOutputAllocate.h"
+#include "Kit/System/Trace.h"
+#include <string.h>
+
+#define SECT_ "_0test"
+
+///
+using namespace Kit::System;
+using namespace Kit::Framing;
+
+
+////////////////////////////////////
+TEST_CASE( "StreamSource" )
+{
+    ShutdownUnitTesting::clearAndUseCounter();
+    Kit::Io::Ram::InputOutputAllocate<64> dst; // Must be large enough to hold the test string TWICE
+    StreamSource                          uut( dst );
+    char                                  buffer[14];
+    Kit::Type::SSize_T                    bytesRead;
+
+    dst.write( "Hello Kitty!" );
+    REQUIRE( uut.read( buffer, 5, bytesRead ) == true );
+    REQUIRE( bytesRead == 5 );
+    REQUIRE( strncmp( buffer, "Hello", 5 ) == 0 );
+    REQUIRE( uut.read( nullptr, 5, bytesRead ) == false );
+    REQUIRE( bytesRead == 0 );
+    REQUIRE( uut.read( buffer, sizeof( buffer ), bytesRead ) == true );
+    REQUIRE( bytesRead == 7 );
+    REQUIRE( strcmp( buffer, " Kitty!" ) == 0 );
+    REQUIRE( uut.read( buffer, sizeof( buffer ), bytesRead ) == false );
+    REQUIRE( bytesRead == 0 );
+
+    StreamSource uut2;
+    memset( buffer, 0, sizeof( buffer ) );
+    REQUIRE( uut2.read( buffer, 5, bytesRead ) == false );
+    REQUIRE( bytesRead == 0 );
+    uut2.setInput( dst );
+    dst.write( "Hello Kitty!" );
+    REQUIRE( uut2.read( buffer, 5, bytesRead ) == true );
+    REQUIRE( bytesRead == 5 );
+    REQUIRE( strncmp( buffer, "Hello", 5 ) == 0 );
+    memset( buffer, 0, sizeof( buffer ) );
+    REQUIRE( uut2.read( buffer, sizeof( buffer ), bytesRead ) == true );
+    REQUIRE( bytesRead == 7 );
+    REQUIRE( strcmp( buffer, " Kitty!" ) == 0 );
+    REQUIRE( uut2.read( buffer, sizeof( buffer ), bytesRead ) == false );
+    REQUIRE( bytesRead == 0 );
+
+    dst.close();
+    REQUIRE( uut2.read( buffer, sizeof( buffer ), bytesRead ) == false );
+
+    REQUIRE( ShutdownUnitTesting::getAndClearCounter() == 0u );
+}

--- a/src/Kit/Framing/_0test/streamsource.cpp
+++ b/src/Kit/Framing/_0test/streamsource.cpp
@@ -39,7 +39,7 @@ TEST_CASE( "StreamSource" )
     REQUIRE( bytesRead == 0 );
     REQUIRE( uut.read( buffer, sizeof( buffer ), bytesRead ) == true );
     REQUIRE( bytesRead == 7 );
-    REQUIRE( strcmp( buffer, " Kitty!" ) == 0 );
+    REQUIRE( strncmp( buffer, " Kitty!", 7 ) == 0 );
     REQUIRE( uut.read( buffer, sizeof( buffer ), bytesRead ) == false );
     REQUIRE( bytesRead == 0 );
 
@@ -55,7 +55,7 @@ TEST_CASE( "StreamSource" )
     memset( buffer, 0, sizeof( buffer ) );
     REQUIRE( uut2.read( buffer, sizeof( buffer ), bytesRead ) == true );
     REQUIRE( bytesRead == 7 );
-    REQUIRE( strcmp( buffer, " Kitty!" ) == 0 );
+    REQUIRE( strncmp( buffer, " Kitty!", 7 ) == 0 );
     REQUIRE( uut2.read( buffer, sizeof( buffer ), bytesRead ) == false );
     REQUIRE( bytesRead == 0 );
 

--- a/src/Kit/Framing/_0test/stringsource.cpp
+++ b/src/Kit/Framing/_0test/stringsource.cpp
@@ -1,0 +1,67 @@
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/System/_testsupport/ShutdownUnitTesting.h"
+#include "catch2/catch_test_macros.hpp"
+#include "Kit/Framing/StringSource.h"
+#include "Kit/System/Trace.h"
+#include <string.h>
+
+#define SECT_ "_0test"
+
+///
+using namespace Kit::System;
+using namespace Kit::Framing;
+
+
+////////////////////////////////////
+TEST_CASE( "StringSource" )
+{
+    ShutdownUnitTesting::clearAndUseCounter();
+    const char*                           testString = "Hello Kitty!";
+    StringSource                          uut( testString);
+    char                                  buffer[14];
+    Kit::Type::SSize_T                    bytesRead;
+
+    REQUIRE( uut.read( buffer, 5, bytesRead ) == true );
+    REQUIRE( bytesRead == 5 );
+    REQUIRE( strncmp( buffer, "Hello", 5 ) == 0 );
+    REQUIRE( uut.read( nullptr, 5, bytesRead ) == false );
+    REQUIRE( bytesRead == 0 );
+    REQUIRE( uut.read( buffer, sizeof( buffer ), bytesRead ) == true );
+    REQUIRE( bytesRead == 7 );
+    REQUIRE( strcmp( buffer, " Kitty!" ) == 0 );
+    REQUIRE( uut.read( buffer, sizeof( buffer ), bytesRead ) == false );
+    REQUIRE( bytesRead == 0 );
+
+    StringSource uut2;
+    memset( buffer, 0, sizeof( buffer ) );
+    REQUIRE( uut2.read( buffer, 5, bytesRead ) == false );
+    REQUIRE( bytesRead == 0 );
+    uut2.setInput( testString );
+    REQUIRE( uut2.read( buffer, 5, bytesRead ) == true );
+    REQUIRE( bytesRead == 5 );
+    REQUIRE( strncmp( buffer, "Hello", 5 ) == 0 );
+    memset( buffer, 0, sizeof( buffer ) );
+    REQUIRE( uut2.read( buffer, sizeof( buffer ), bytesRead ) == true );
+    REQUIRE( bytesRead == 7 );
+    REQUIRE( strcmp( buffer, " Kitty!" ) == 0 );
+    REQUIRE( uut2.read( buffer, sizeof( buffer ), bytesRead ) == false );
+    REQUIRE( bytesRead == 0 );
+
+    StringSource uut3( nullptr );
+    REQUIRE( uut2.read( buffer, 5, bytesRead ) == false );
+    REQUIRE( bytesRead == 0 );
+    uut3.setInput( nullptr );
+    REQUIRE( uut2.read( buffer, 5, bytesRead ) == false );
+    REQUIRE( bytesRead == 0 );
+
+    REQUIRE( ShutdownUnitTesting::getAndClearCounter() == 0u );
+}

--- a/src/Kit/Framing/_0test/stringsource.cpp
+++ b/src/Kit/Framing/_0test/stringsource.cpp
@@ -37,7 +37,7 @@ TEST_CASE( "StringSource" )
     REQUIRE( bytesRead == 0 );
     REQUIRE( uut.read( buffer, sizeof( buffer ), bytesRead ) == true );
     REQUIRE( bytesRead == 7 );
-    REQUIRE( strcmp( buffer, " Kitty!" ) == 0 );
+    REQUIRE( strncmp( buffer, " Kitty!", 7 ) == 0 );
     REQUIRE( uut.read( buffer, sizeof( buffer ), bytesRead ) == false );
     REQUIRE( bytesRead == 0 );
 
@@ -52,7 +52,7 @@ TEST_CASE( "StringSource" )
     memset( buffer, 0, sizeof( buffer ) );
     REQUIRE( uut2.read( buffer, sizeof( buffer ), bytesRead ) == true );
     REQUIRE( bytesRead == 7 );
-    REQUIRE( strcmp( buffer, " Kitty!" ) == 0 );
+    REQUIRE( strncmp( buffer, " Kitty!", 7 ) == 0 );
     REQUIRE( uut2.read( buffer, sizeof( buffer ), bytesRead ) == false );
     REQUIRE( bytesRead == 0 );
 

--- a/src/Kit/Io/File/IPosition.h
+++ b/src/Kit/Io/File/IPosition.h
@@ -39,26 +39,26 @@ public:
     /** Returns the length, in bytes, of the file. If there is an error than
         false is returned.
      */
-    virtual bool length( ByteCount_T& length ) noexcept = 0;
+    virtual bool length( Kit::Type::SSize_T& length ) noexcept = 0;
 
 
 public:
     /** Returns the current file pointer offset, in bytes, from the top of the
         file.  If there is an error than false is returned.
      */
-    virtual bool currentPos( ByteCount_T& currentPos ) noexcept = 0;
+    virtual bool currentPos( Kit::Type::SSize_T& currentPos ) noexcept = 0;
 
     /** Adjusts the current pointer offset by the specified delta (in bytes).
         Returns true if successful, else false (i.e. setting the pointer
         past/before the file boundaries).
      */
-    virtual bool setRelativePos( ByteCount_T deltaOffset ) noexcept = 0;
+    virtual bool setRelativePos( Kit::Type::SSize_T deltaOffset ) noexcept = 0;
 
     /** Sets the file pointer to the absolute specified offset (in bytes).
         Returns true if successful, else false (i.e. setting the
         pointer past the end of the file).
      */
-    virtual bool setAbsolutePos( ByteCount_T newoffset ) noexcept = 0;
+    virtual bool setAbsolutePos( Kit::Type::SSize_T newoffset ) noexcept = 0;
 
     /** Sets the file pointer to End-Of-File.  Returns true  if successful, else
         false if an error occurred.

--- a/src/Kit/Io/File/Input.h
+++ b/src/Kit/Io/File/Input.h
@@ -47,7 +47,7 @@ public:
     using Kit::Io::IInput::read;
 
     /// See Kit::Io::IInput
-    bool read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept override;
+    bool read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept override;
 
     /// See Kit::Io::IInput
     bool available() noexcept override;
@@ -63,16 +63,16 @@ public:
     bool isEof() noexcept override;
 
     /// See Kit::Io::File::IPosition
-    bool length( ByteCount_T& len) noexcept override;
+    bool length( Kit::Type::SSize_T& len) noexcept override;
 
     /// See Kit::Io::File::IPosition
-    bool currentPos( ByteCount_T& curPos ) noexcept override;
+    bool currentPos( Kit::Type::SSize_T& curPos ) noexcept override;
 
     /// See Kit::Io::File::IPosition
-    bool setRelativePos( ByteCount_T deltaOffset ) noexcept override;
+    bool setRelativePos( Kit::Type::SSize_T deltaOffset ) noexcept override;
 
     /// See Kit::Io::File::IPosition
-    bool setAbsolutePos( ByteCount_T newoffset ) noexcept override;
+    bool setAbsolutePos( Kit::Type::SSize_T newoffset ) noexcept override;
 
     /// See Kit::Io::File::IPosition
     bool setToEof() noexcept override;

--- a/src/Kit/Io/File/InputOutput.h
+++ b/src/Kit/Io/File/InputOutput.h
@@ -52,7 +52,7 @@ public:
     using Kit::Io::IInput::read;
 
     /// See Kit::Io::IInput
-    bool read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept override;
+    bool read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept override;
 
     /// See Kit::Io::IInput
     bool available() noexcept override;
@@ -69,7 +69,7 @@ public:
     using Kit::Io::IOutput::write;
 
     /// See Kit::Io::IOutput
-    bool write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept override;
+    bool write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept override;
 
     /// See Kit::Io::IOutput
     void flush() noexcept override;
@@ -80,16 +80,16 @@ public:
     bool isEof() noexcept override;
 
     /// See Kit::Io::File::IPosition
-    bool length( ByteCount_T& len ) noexcept override;
+    bool length( Kit::Type::SSize_T& len ) noexcept override;
 
     /// See Kit::Io::File::IPosition
-    bool currentPos( ByteCount_T& curPos ) noexcept override;
+    bool currentPos( Kit::Type::SSize_T& curPos ) noexcept override;
 
     /// See Kit::Io::File::IPosition
-    bool setRelativePos( ByteCount_T deltaOffset ) noexcept override;
+    bool setRelativePos( Kit::Type::SSize_T deltaOffset ) noexcept override;
 
     /// See Kit::Io::File::IPosition
-    bool setAbsolutePos( ByteCount_T newoffset ) noexcept override;
+    bool setAbsolutePos( Kit::Type::SSize_T newoffset ) noexcept override;
 
     /// See Kit::Io::File::IPosition
     bool setToEof() noexcept override;

--- a/src/Kit/Io/File/Null.cpp
+++ b/src/Kit/Io/File/Null.cpp
@@ -23,7 +23,7 @@ Null::Null()
 
 
 //////////////////////
-bool Null::read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept
+bool Null::read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept
 {
     bytesRead = 0;
     return false;
@@ -36,7 +36,7 @@ bool Null::available() noexcept
 
 
 //////////////////////
-bool Null::write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept
+bool Null::write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept
 {
     bytesWritten = maxBytes;
     return m_opened;
@@ -65,24 +65,24 @@ bool Null::isEof() noexcept
     return isEos();
 }
 
-bool Null::length( ByteCount_T& len ) noexcept
+bool Null::length( Kit::Type::SSize_T& len ) noexcept
 {
     len = 0;
     return m_opened;
 }
 
-bool Null::currentPos( ByteCount_T& curPos ) noexcept
+bool Null::currentPos( Kit::Type::SSize_T& curPos ) noexcept
 {
     curPos = 0;
     return m_opened;
 }
 
-bool Null::setRelativePos( ByteCount_T deltaOffset ) noexcept
+bool Null::setRelativePos( Kit::Type::SSize_T deltaOffset ) noexcept
 {
     return m_opened;
 }
 
-bool Null::setAbsolutePos( ByteCount_T newoffset ) noexcept
+bool Null::setAbsolutePos( Kit::Type::SSize_T newoffset ) noexcept
 {
     return m_opened;
 }

--- a/src/Kit/Io/File/Null.h
+++ b/src/Kit/Io/File/Null.h
@@ -37,7 +37,7 @@ public:
     using Kit::Io::IInput::read;
 
     /// See Kit::Io::IInput
-    bool read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept override;
+    bool read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept override;
 
     /// See Kit::Io::IInput
     bool available() noexcept override;
@@ -48,7 +48,7 @@ public:
     using Kit::Io::IOutput::write;
 
     /// See Kit::Io::Output
-    bool write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept override;
+    bool write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept override;
 
     /// See Kit::Io::File::IOutput
     void flush() noexcept override;
@@ -65,16 +65,16 @@ public:
     bool isEof() noexcept override;
 
     /// See Kit::Io::File::IPosition
-    bool length( ByteCount_T& len ) noexcept override;
+    bool length( Kit::Type::SSize_T& len ) noexcept override;
 
     /// See Kit::Io::File::IPosition
-    bool currentPos( ByteCount_T& curPos ) noexcept override;
+    bool currentPos( Kit::Type::SSize_T& curPos ) noexcept override;
 
     /// See Kit::Io::File::IPosition
-    bool setRelativePos( ByteCount_T deltaOffset ) noexcept override;
+    bool setRelativePos( Kit::Type::SSize_T deltaOffset ) noexcept override;
 
     /// See Kit::Io::File::IPosition
-    bool setAbsolutePos( ByteCount_T newoffset ) noexcept override;
+    bool setAbsolutePos( Kit::Type::SSize_T newoffset ) noexcept override;
 
     /// See Kit::Io::File::IPosition
     bool setToEof() noexcept override;

--- a/src/Kit/Io/File/Output.h
+++ b/src/Kit/Io/File/Output.h
@@ -54,7 +54,7 @@ public:
     using Kit::Io::IOutput::write;
 
     /// See Kit::Io::IOutput
-    bool write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept override;
+    bool write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept override;
 
     /// See Kit::Io::IOutput
     void flush() noexcept override;
@@ -70,16 +70,16 @@ public:
     bool isEof() noexcept override;
 
     /// See Kit::Io::File::IPosition
-    bool length( ByteCount_T& len ) noexcept override;
+    bool length( Kit::Type::SSize_T& len ) noexcept override;
 
     /// See Kit::Io::File::IPosition
-    bool currentPos( ByteCount_T& curPos ) noexcept override;
+    bool currentPos( Kit::Type::SSize_T& curPos ) noexcept override;
 
     /// See Kit::Io::File::IPosition
-    bool setRelativePos( ByteCount_T deltaOffset ) noexcept override;
+    bool setRelativePos( Kit::Type::SSize_T deltaOffset ) noexcept override;
 
     /// See Kit::Io::File::IPosition
-    bool setAbsolutePos( ByteCount_T newoffset ) noexcept override;
+    bool setAbsolutePos( Kit::Type::SSize_T newoffset ) noexcept override;
 
     /// See Kit::Io::File::IPosition
     bool setToEof() noexcept override;

--- a/src/Kit/Io/File/Posix/Fdio.cpp
+++ b/src/Kit/Io/File/Posix/Fdio.cpp
@@ -47,7 +47,7 @@ KitIoFileHandle_T Fdio::open( const char* fileEntryName, bool readOnly, bool for
     return fd;
 }
 
-bool Fdio::length( KitIoFileHandle_T fd, ByteCount_T& length ) noexcept
+bool Fdio::length( KitIoFileHandle_T fd, Kit::Type::SSize_T& length ) noexcept
 {
     if ( fd == INVALID_FD )
     {
@@ -57,11 +57,11 @@ bool Fdio::length( KitIoFileHandle_T fd, ByteCount_T& length ) noexcept
     off_t cur     = lseek( fd, 0, SEEK_CUR );
     off_t eof     = lseek( fd, 0, SEEK_END );
     off_t restore = lseek( fd, cur, SEEK_SET );
-    length        = (ByteCount_T)eof;
+    length        = (Kit::Type::SSize_T)eof;
     return ( cur != (off_t)-1 ) && ( eof != (off_t)-1 ) && ( restore != (off_t)-1 );
 }
 
-bool Fdio::currentPos( KitIoFileHandle_T fd, ByteCount_T& currentPos ) noexcept
+bool Fdio::currentPos( KitIoFileHandle_T fd, Kit::Type::SSize_T& currentPos ) noexcept
 {
     if ( fd == INVALID_FD )
     {
@@ -69,11 +69,11 @@ bool Fdio::currentPos( KitIoFileHandle_T fd, ByteCount_T& currentPos ) noexcept
     }
 
     off_t pos  = lseek( fd, 0, SEEK_CUR );
-    currentPos = (ByteCount_T)pos;
+    currentPos = (Kit::Type::SSize_T)pos;
     return pos != (off_t)-1;
 }
 
-bool Fdio::setRelativePos( KitIoFileHandle_T fd, ByteCount_T deltaOffset ) noexcept
+bool Fdio::setRelativePos( KitIoFileHandle_T fd, Kit::Type::SSize_T deltaOffset ) noexcept
 {
     if ( fd == INVALID_FD )
     {
@@ -84,7 +84,7 @@ bool Fdio::setRelativePos( KitIoFileHandle_T fd, ByteCount_T deltaOffset ) noexc
     return pos != (off_t)-1;
 }
 
-bool Fdio::setAbsolutePos( KitIoFileHandle_T fd, ByteCount_T newoffset ) noexcept
+bool Fdio::setAbsolutePos( KitIoFileHandle_T fd, Kit::Type::SSize_T newoffset ) noexcept
 {
     if ( fd == INVALID_FD )
     {

--- a/src/Kit/Io/File/Posix/Fdio.h
+++ b/src/Kit/Io/File/Posix/Fdio.h
@@ -49,25 +49,25 @@ public:
         offset as the length. The file position indicator is restored to its
         original position before returning.
      */
-    static bool length( KitIoFileHandle_T fd, ByteCount_T& length ) noexcept;
+    static bool length( KitIoFileHandle_T fd, Kit::Type::SSize_T& length ) noexcept;
 
 public:
     /** Returns the current file pointer offset, in bytes, from the top of the
         file.  If there is an error than false is returned.
      */
-    static bool currentPos( KitIoFileHandle_T fd, ByteCount_T& currentPos ) noexcept;
+    static bool currentPos( KitIoFileHandle_T fd, Kit::Type::SSize_T& currentPos ) noexcept;
 
     /** Adjusts the current pointer offset by the specified delta (in bytes).
         Returns true if successful, else false (i.e. setting the pointer
         past/before the file boundaries).
      */
-    static bool setRelativePos( KitIoFileHandle_T fd, ByteCount_T deltaOffset ) noexcept;
+    static bool setRelativePos( KitIoFileHandle_T fd, Kit::Type::SSize_T deltaOffset ) noexcept;
 
     /** Sets the file pointer to the absolute specified offset (in bytes).
         Returns true if successful, else false (i.e. setting the
         pointer past the end of the file).
      */
-    static bool setAbsolutePos( KitIoFileHandle_T fd, ByteCount_T newoffset ) noexcept;
+    static bool setAbsolutePos( KitIoFileHandle_T fd, Kit::Type::SSize_T newoffset ) noexcept;
 
     /** Sets the file pointer to End-Of-File.  Returns true  if successful, else
         false if an error occurred.

--- a/src/Kit/Io/File/Posix/Input.cpp
+++ b/src/Kit/Io/File/Posix/Input.cpp
@@ -39,7 +39,7 @@ bool Input::isOpened() noexcept
 
 
 //////////////////////////
-bool Input::read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept
+bool Input::read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept
 {
     m_inEos = false;
     return Posix::Fdio::read( m_inFd, m_inEos, buffer, numBytes, bytesRead );
@@ -62,12 +62,12 @@ void Input::close() noexcept
 
 
 //////////////////////////
-bool Input::currentPos( ByteCount_T& curPos ) noexcept
+bool Input::currentPos( Kit::Type::SSize_T& curPos ) noexcept
 {
     return Posix::Fdio::currentPos( m_inFd, curPos );
 }
 
-bool Input::setRelativePos( ByteCount_T deltaOffset ) noexcept
+bool Input::setRelativePos( Kit::Type::SSize_T deltaOffset ) noexcept
 {
     return Posix::Fdio::setRelativePos( m_inFd, deltaOffset );
 }
@@ -77,7 +77,7 @@ bool Input::setToEof() noexcept
     return Posix::Fdio::setToEof( m_inFd );
 }
 
-bool Input::setAbsolutePos( ByteCount_T newoffset ) noexcept
+bool Input::setAbsolutePos( Kit::Type::SSize_T newoffset ) noexcept
 {
     return Posix::Fdio::setAbsolutePos( m_inFd, newoffset );
 }
@@ -87,7 +87,7 @@ bool Input::isEof() noexcept
     return isEos();
 }
 
-bool Input::length( ByteCount_T& len ) noexcept
+bool Input::length( Kit::Type::SSize_T& len ) noexcept
 {
     return Posix::Fdio::length( m_inFd, len );
 }

--- a/src/Kit/Io/File/Posix/InputOutput.cpp
+++ b/src/Kit/Io/File/Posix/InputOutput.cpp
@@ -38,7 +38,7 @@ bool InputOutput::isOpened() noexcept
 
 
 //////////////////////////
-bool InputOutput::read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept
+bool InputOutput::read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept
 {
     m_eos = false;
     return Posix::Fdio::read( m_fd, m_eos, buffer, numBytes, bytesRead );
@@ -61,7 +61,7 @@ void InputOutput::close() noexcept
 
 
 //////////////////////////
-bool InputOutput::write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept
+bool InputOutput::write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept
 {
     m_eos = false;
     return Posix::Fdio::write( m_fd, m_eos, buffer, maxBytes, bytesWritten );
@@ -74,12 +74,12 @@ void InputOutput::flush() noexcept
 
 
 //////////////////////////
-bool InputOutput::currentPos( ByteCount_T& curPos ) noexcept
+bool InputOutput::currentPos( Kit::Type::SSize_T& curPos ) noexcept
 {
     return Posix::Fdio::currentPos( m_fd, curPos );
 }
 
-bool InputOutput::setRelativePos( ByteCount_T deltaOffset ) noexcept
+bool InputOutput::setRelativePos( Kit::Type::SSize_T deltaOffset ) noexcept
 {
     return Posix::Fdio::setRelativePos( m_fd, deltaOffset );
 }
@@ -89,7 +89,7 @@ bool InputOutput::setToEof() noexcept
     return Posix::Fdio::setToEof( m_fd );
 }
 
-bool InputOutput::setAbsolutePos( ByteCount_T newoffset ) noexcept
+bool InputOutput::setAbsolutePos( Kit::Type::SSize_T newoffset ) noexcept
 {
     return Posix::Fdio::setAbsolutePos( m_fd, newoffset );
 }
@@ -99,7 +99,7 @@ bool InputOutput::isEof() noexcept
     return isEos();
 }
 
-bool InputOutput::length( ByteCount_T& len ) noexcept
+bool InputOutput::length( Kit::Type::SSize_T& len ) noexcept
 {
     return Posix::Fdio::length( m_fd, len );
 }

--- a/src/Kit/Io/File/Posix/Output.cpp
+++ b/src/Kit/Io/File/Posix/Output.cpp
@@ -39,7 +39,7 @@ bool Output::isOpened()
 
 
 //////////////////////////
-bool Output::write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept
+bool Output::write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept
 {
     m_outEos = false;
     return Posix::Fdio::write( m_outFd, m_outEos, buffer, maxBytes, bytesWritten );
@@ -62,12 +62,12 @@ void Output::close() noexcept
 
 
 //////////////////////////
-bool Output::currentPos( ByteCount_T& curPos ) noexcept
+bool Output::currentPos( Kit::Type::SSize_T& curPos ) noexcept
 {
     return Posix::Fdio::currentPos( m_outFd, curPos );
 }
 
-bool Output::setRelativePos( ByteCount_T deltaOffset ) noexcept
+bool Output::setRelativePos( Kit::Type::SSize_T deltaOffset ) noexcept
 {
     return Posix::Fdio::setRelativePos( m_outFd, deltaOffset );
 }
@@ -77,7 +77,7 @@ bool Output::setToEof() noexcept
     return Posix::Fdio::setToEof( m_outFd );
 }
 
-bool Output::setAbsolutePos( ByteCount_T newoffset ) noexcept
+bool Output::setAbsolutePos( Kit::Type::SSize_T newoffset ) noexcept
 {
     return Posix::Fdio::setAbsolutePos( m_outFd, newoffset );
 }
@@ -87,7 +87,7 @@ bool Output::isEof() noexcept
     return isEos();
 }
 
-bool Output::length( ByteCount_T& len ) noexcept
+bool Output::length( Kit::Type::SSize_T& len ) noexcept
 {
     return Posix::Fdio::length( m_outFd, len );
 }

--- a/src/Kit/Io/File/System.cpp
+++ b/src/Kit/Io/File/System.cpp
@@ -135,7 +135,7 @@ bool System::isWriteable( const char* fsEntryName ) noexcept
     return false;
 }
 
-ByteCount_T System::size( const char* fsEntryName ) noexcept
+Kit::Type::SSize_T System::size( const char* fsEntryName ) noexcept
 {
     System::Info_T entryInfo;
     if ( System::getInfo( fsEntryName, entryInfo ) )

--- a/src/Kit/Io/File/System.h
+++ b/src/Kit/Io/File/System.h
@@ -95,7 +95,7 @@ public:
     /** Returns the size, in bytes, of the file.  If the File Entry is not
         a file or an error occurs, then 0 is returned.
      */
-    static ByteCount_T size( const char* fsEntryName ) noexcept;
+    static Kit::Type::SSize_T size( const char* fsEntryName ) noexcept;
 
     /** Returns the time/date the file entry was last modified. If an error
         occurred, then  ((time_t)-1) is returned.
@@ -107,7 +107,7 @@ public:
     struct Info_T
     {
         /// Size, in bytes, of the file entry
-        ByteCount_T m_size;
+        Kit::Type::SSize_T m_size;
 
         /// Time the file entry was last modified/written
         time_t m_mtime;

--- a/src/Kit/Io/File/Win32/Fdio.cpp
+++ b/src/Kit/Io/File/Win32/Fdio.cpp
@@ -52,7 +52,7 @@ KitIoFileHandle_T Fdio::open( const char* fileEntryName, bool readOnly, bool for
     return fd;
 }
 
-bool Fdio::length( KitIoFileHandle_T fd, ByteCount_T& length ) noexcept
+bool Fdio::length( KitIoFileHandle_T fd, Kit::Type::SSize_T& length ) noexcept
 {
     if ( fd == INVALID_HANDLE_VALUE )
     {
@@ -71,11 +71,11 @@ bool Fdio::length( KitIoFileHandle_T fd, ByteCount_T& length ) noexcept
         }
     }
 
-    length = static_cast<ByteCount_T>( len );
+    length = static_cast<Kit::Type::SSize_T>( len );
     return true;
 }
 
-bool Fdio::currentPos( KitIoFileHandle_T fd, ByteCount_T& currentPos ) noexcept
+bool Fdio::currentPos( KitIoFileHandle_T fd, Kit::Type::SSize_T& currentPos ) noexcept
 {
     if ( fd == INVALID_HANDLE_VALUE )
     {
@@ -94,11 +94,11 @@ bool Fdio::currentPos( KitIoFileHandle_T fd, ByteCount_T& currentPos ) noexcept
         }
     }
 
-    currentPos = static_cast<ByteCount_T>( pos );
+    currentPos = static_cast<Kit::Type::SSize_T>( pos );
     return true;
 }
 
-bool Fdio::setRelativePos( KitIoFileHandle_T fd, ByteCount_T deltaOffset ) noexcept
+bool Fdio::setRelativePos( KitIoFileHandle_T fd, Kit::Type::SSize_T deltaOffset ) noexcept
 {
     if ( fd == INVALID_HANDLE_VALUE )
     {
@@ -116,7 +116,7 @@ bool Fdio::setRelativePos( KitIoFileHandle_T fd, ByteCount_T deltaOffset ) noexc
     return true;
 }
 
-bool Fdio::setAbsolutePos( KitIoFileHandle_T fd, ByteCount_T newoffset ) noexcept
+bool Fdio::setAbsolutePos( KitIoFileHandle_T fd, Kit::Type::SSize_T newoffset ) noexcept
 {
     if ( fd == INVALID_HANDLE_VALUE )
     {

--- a/src/Kit/Io/File/Win32/Fdio.h
+++ b/src/Kit/Io/File/Win32/Fdio.h
@@ -48,25 +48,25 @@ public:
         offset as the length. The file position indicator is restored to its
         original position before returning.
      */
-    static bool length( KitIoFileHandle_T fd, ByteCount_T& length ) noexcept;
+    static bool length( KitIoFileHandle_T fd, Kit::Type::SSize_T& length ) noexcept;
 
 public:
     /** Returns the current file pointer offset, in bytes, from the top of the
         file.  If there is an error than false is returned.
      */
-    static bool currentPos( KitIoFileHandle_T fd, ByteCount_T& currentPos ) noexcept;
+    static bool currentPos( KitIoFileHandle_T fd, Kit::Type::SSize_T& currentPos ) noexcept;
 
     /** Adjusts the current pointer offset by the specified delta (in bytes).
         Returns true if successful, else false (i.e. setting the pointer
         past/before the file boundaries).
      */
-    static bool setRelativePos( KitIoFileHandle_T fd, ByteCount_T deltaOffset ) noexcept;
+    static bool setRelativePos( KitIoFileHandle_T fd, Kit::Type::SSize_T deltaOffset ) noexcept;
 
     /** Sets the file pointer to the absolute specified offset (in bytes).
         Returns true if successful, else false (i.e. setting the
         pointer past the end of the file).
      */
-    static bool setAbsolutePos( KitIoFileHandle_T fd, ByteCount_T newoffset ) noexcept;
+    static bool setAbsolutePos( KitIoFileHandle_T fd, Kit::Type::SSize_T newoffset ) noexcept;
 
     /** Sets the file pointer to End-Of-File.  Returns true  if successful, else
         false if an error occurred.

--- a/src/Kit/Io/File/Win32/Input.cpp
+++ b/src/Kit/Io/File/Win32/Input.cpp
@@ -39,7 +39,7 @@ bool Input::isOpened() noexcept
 
 
 //////////////////////////
-bool Input::read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept
+bool Input::read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept
 {
     m_inEos = false;
     return Win32::Fdio::read( m_inFd, m_inEos, buffer, numBytes, bytesRead );
@@ -62,12 +62,12 @@ void Input::close() noexcept
 
 
 //////////////////////////
-bool Input::currentPos( ByteCount_T& curPos ) noexcept
+bool Input::currentPos( Kit::Type::SSize_T& curPos ) noexcept
 {
     return Win32::Fdio::currentPos( m_inFd, curPos );
 }
 
-bool Input::setRelativePos( ByteCount_T deltaOffset ) noexcept
+bool Input::setRelativePos( Kit::Type::SSize_T deltaOffset ) noexcept
 {
     return Win32::Fdio::setRelativePos( m_inFd, deltaOffset );
 }
@@ -77,7 +77,7 @@ bool Input::setToEof() noexcept
     return Win32::Fdio::setToEof( m_inFd );
 }
 
-bool Input::setAbsolutePos( ByteCount_T newoffset ) noexcept
+bool Input::setAbsolutePos( Kit::Type::SSize_T newoffset ) noexcept
 {
     return Win32::Fdio::setAbsolutePos( m_inFd, newoffset );
 }
@@ -87,7 +87,7 @@ bool Input::isEof() noexcept
     return isEos();
 }
 
-bool Input::length( ByteCount_T& len ) noexcept
+bool Input::length( Kit::Type::SSize_T& len ) noexcept
 {
     return Win32::Fdio::length( m_inFd, len );
 }

--- a/src/Kit/Io/File/Win32/InputOutput.cpp
+++ b/src/Kit/Io/File/Win32/InputOutput.cpp
@@ -38,7 +38,7 @@ bool InputOutput::isOpened() noexcept
 
 
 //////////////////////////
-bool InputOutput::read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept
+bool InputOutput::read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept
 {
     m_eos = false;
     return Win32::Fdio::read( m_fd, m_eos, buffer, numBytes, bytesRead );
@@ -61,7 +61,7 @@ void InputOutput::close() noexcept
 
 
 //////////////////////////
-bool InputOutput::write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept
+bool InputOutput::write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept
 {
     m_eos = false;
     return Win32::Fdio::write( m_fd, m_eos, buffer, maxBytes, bytesWritten );
@@ -74,12 +74,12 @@ void InputOutput::flush() noexcept
 
 
 //////////////////////////
-bool InputOutput::currentPos( ByteCount_T& curPos ) noexcept
+bool InputOutput::currentPos( Kit::Type::SSize_T& curPos ) noexcept
 {
     return Win32::Fdio::currentPos( m_fd, curPos );
 }
 
-bool InputOutput::setRelativePos( ByteCount_T deltaOffset ) noexcept
+bool InputOutput::setRelativePos( Kit::Type::SSize_T deltaOffset ) noexcept
 {
     return Win32::Fdio::setRelativePos( m_fd, deltaOffset );
 }
@@ -89,7 +89,7 @@ bool InputOutput::setToEof() noexcept
     return Win32::Fdio::setToEof( m_fd );
 }
 
-bool InputOutput::setAbsolutePos( ByteCount_T newoffset ) noexcept
+bool InputOutput::setAbsolutePos( Kit::Type::SSize_T newoffset ) noexcept
 {
     return Win32::Fdio::setAbsolutePos( m_fd, newoffset );
 }
@@ -99,7 +99,7 @@ bool InputOutput::isEof() noexcept
     return isEos();
 }
 
-bool InputOutput::length( ByteCount_T& len ) noexcept
+bool InputOutput::length( Kit::Type::SSize_T& len ) noexcept
 {
     return Win32::Fdio::length( m_fd, len );
 }

--- a/src/Kit/Io/File/Win32/Output.cpp
+++ b/src/Kit/Io/File/Win32/Output.cpp
@@ -39,7 +39,7 @@ bool Output::isOpened()
 
 
 //////////////////////////
-bool Output::write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept
+bool Output::write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept
 {
     m_outEos = false;
     return Win32::Fdio::write( m_outFd, m_outEos, buffer, maxBytes, bytesWritten );
@@ -62,12 +62,12 @@ void Output::close() noexcept
 
 
 //////////////////////////
-bool Output::currentPos( ByteCount_T& curPos ) noexcept
+bool Output::currentPos( Kit::Type::SSize_T& curPos ) noexcept
 {
     return Win32::Fdio::currentPos( m_outFd, curPos );
 }
 
-bool Output::setRelativePos( ByteCount_T deltaOffset ) noexcept
+bool Output::setRelativePos( Kit::Type::SSize_T deltaOffset ) noexcept
 {
     return Win32::Fdio::setRelativePos( m_outFd, deltaOffset );
 }
@@ -77,7 +77,7 @@ bool Output::setToEof() noexcept
     return Win32::Fdio::setToEof( m_outFd );
 }
 
-bool Output::setAbsolutePos( ByteCount_T newoffset ) noexcept
+bool Output::setAbsolutePos( Kit::Type::SSize_T newoffset ) noexcept
 {
     return Win32::Fdio::setAbsolutePos( m_outFd, newoffset );
 }
@@ -87,7 +87,7 @@ bool Output::isEof() noexcept
     return isEos();
 }
 
-bool Output::length( ByteCount_T& len ) noexcept
+bool Output::length( Kit::Type::SSize_T& len ) noexcept
 {
     return Win32::Fdio::length( m_outFd, len );
 }

--- a/src/Kit/Io/File/_0test/position.cpp
+++ b/src/Kit/Io/File/_0test/position.cpp
@@ -41,7 +41,7 @@ TEST_CASE( "iposition output" )
 
     SECTION( "output: absolute" )
     {
-        Kit::Io::ByteCount_T pos;
+        Kit::Type::SSize_T pos;
         REQUIRE( fd.currentPos( pos ) == true );
         REQUIRE( pos == 0 );
         REQUIRE( fd.write( OUTPUT_TXT ) );
@@ -51,7 +51,7 @@ TEST_CASE( "iposition output" )
         fd.setAbsolutePos( 0 );
         REQUIRE( fd.write( OUTPUT_TXT2 ) );
         fd.flush();
-        Kit::Io::ByteCount_T len;
+        Kit::Type::SSize_T len;
         REQUIRE( fd.length( len ) == true );
         REQUIRE( len == strlen( OUTPUT_TXT ) );
         REQUIRE( fd.currentPos( pos ) == true );
@@ -75,7 +75,7 @@ TEST_CASE( "iposition output" )
 
     SECTION( "output: relative" )
     {
-        Kit::Io::ByteCount_T pos;
+        Kit::Type::SSize_T pos;
         REQUIRE( fd.currentPos( pos ) == true );
         REQUIRE( pos == 0 );
         REQUIRE( fd.write( OUTPUT_TXT ) );
@@ -90,7 +90,7 @@ TEST_CASE( "iposition output" )
 
         Input infd( FILE_NAME );
         REQUIRE( infd.isOpened() );
-        Kit::Io::ByteCount_T len;
+        Kit::Type::SSize_T len;
         REQUIRE( infd.length( len ) == true );
         REQUIRE( len == strlen( OUTPUT_TXT ) );
         REQUIRE( infd.read( buffer ) == true );
@@ -103,7 +103,7 @@ TEST_CASE( "iposition output" )
 
     SECTION( "in/out: absolute" )
     {
-        Kit::Io::ByteCount_T pos;
+        Kit::Type::SSize_T pos;
         REQUIRE( fd.currentPos( pos ) == true );
         REQUIRE( pos == 0 );
         REQUIRE( fd.write( OUTPUT_TXT ) );
@@ -113,7 +113,7 @@ TEST_CASE( "iposition output" )
         fd.setAbsolutePos( 0 );
         REQUIRE( fd.write( OUTPUT_TXT2 ) );
         fd.flush();
-        Kit::Io::ByteCount_T len;
+        Kit::Type::SSize_T len;
         REQUIRE( fd.length( len ) == true );
         REQUIRE( len == strlen( OUTPUT_TXT ) );
         REQUIRE( fd.currentPos( pos ) == true );
@@ -137,7 +137,7 @@ TEST_CASE( "iposition output" )
 
     SECTION( "in/out: relative" )
     {
-        Kit::Io::ByteCount_T pos;
+        Kit::Type::SSize_T pos;
         REQUIRE( fd.currentPos( pos ) == true );
         REQUIRE( pos == 0 );
         REQUIRE( fd.write( OUTPUT_TXT ) );
@@ -152,7 +152,7 @@ TEST_CASE( "iposition output" )
 
         Input infd( FILE_NAME );
         REQUIRE( infd.isOpened() );
-        Kit::Io::ByteCount_T len;
+        Kit::Type::SSize_T len;
         REQUIRE( infd.length( len ) == true );
         REQUIRE( len == strlen( OUTPUT_TXT ) );
         REQUIRE( infd.read( buffer ) == true );
@@ -165,7 +165,7 @@ TEST_CASE( "iposition output" )
 
     SECTION( "in: absolute" )
     {
-        Kit::Io::ByteCount_T pos;
+        Kit::Type::SSize_T pos;
         REQUIRE( fd.currentPos( pos ) == true );
         REQUIRE( pos == 0 );
         REQUIRE( fd.write( OUTPUT_TXT ) );
@@ -175,7 +175,7 @@ TEST_CASE( "iposition output" )
 
         Input infd( FILE_NAME );
         REQUIRE( infd.setAbsolutePos( strlen( OUTPUT_TXT2 ) ) == true );
-        Kit::Io::ByteCount_T curpos;
+        Kit::Type::SSize_T curpos;
         REQUIRE( infd.currentPos( curpos ) == true );
         REQUIRE( curpos == strlen( OUTPUT_TXT2 ) );
         REQUIRE( infd.read( buffer ) == true );
@@ -188,7 +188,7 @@ TEST_CASE( "iposition output" )
 
     SECTION( "in: relative" )
     {
-        Kit::Io::ByteCount_T pos;
+        Kit::Type::SSize_T pos;
         REQUIRE( fd.currentPos( pos ) == true );
         REQUIRE( pos == 0 );
         REQUIRE( fd.write( OUTPUT_TXT ) );
@@ -199,7 +199,7 @@ TEST_CASE( "iposition output" )
         Input infd( FILE_NAME );
         REQUIRE( infd.setToEof() == true );
         REQUIRE( infd.setRelativePos( (long)( strlen( OUTPUT_TXT2 ) ) - (long)( strlen( OUTPUT_TXT ) ) ) == true );
-        Kit::Io::ByteCount_T curpos;
+        Kit::Type::SSize_T curpos;
         REQUIRE( infd.currentPos( curpos ) == true );
         REQUIRE( curpos == strlen( OUTPUT_TXT2 ) );
 

--- a/src/Kit/Io/File/_0test/read.cpp
+++ b/src/Kit/Io/File/_0test/read.cpp
@@ -61,7 +61,7 @@ TEST_CASE( "read" )
         line.removeTrailingSpaces();
         REQUIRE( line.isEmpty() );
 
-        Kit::Io::ByteCount_T len;
+        Kit::Type::SSize_T len;
         REQUIRE( fd.length( len ) == true );
         REQUIRE( ( len == WIN32_TESTINPUT_TXT_FILE_LENGTH || len == POSIX_TESTINPUT_TXT_FILE_LENGTH ) );
 
@@ -113,12 +113,12 @@ TEST_CASE( "read" )
         REQUIRE( fd.available() == false );
 
         REQUIRE( fd.isEof() == true );
-        Kit::Io::ByteCount_T pos;
+        Kit::Type::SSize_T pos;
         REQUIRE( fd.currentPos( pos ) == false );
         REQUIRE( fd.setAbsolutePos( 1 ) == false );
         REQUIRE( fd.setRelativePos( 1 ) == false );
         REQUIRE( fd.setToEof() == false );
-        Kit::Io::ByteCount_T len = 22;
+        Kit::Type::SSize_T len = 22;
         REQUIRE( fd.length( len ) == false );
     }
 

--- a/src/Kit/Io/File/_0test/readwrite.cpp
+++ b/src/Kit/Io/File/_0test/readwrite.cpp
@@ -102,7 +102,7 @@ TEST_CASE( "readwrite" )
     inbuffer.clear();
     REQUIRE( fd3.isOpened() );
     REQUIRE( fd3.setAbsolutePos( 15 ) );
-    Kit::Io::ByteCount_T pos;
+    Kit::Type::SSize_T pos;
     REQUIRE( fd3.currentPos(pos));
     REQUIRE( pos == 15 );
     REQUIRE( fd3.setRelativePos( -14 ) );
@@ -110,7 +110,7 @@ TEST_CASE( "readwrite" )
     REQUIRE( pos == 1 );
     REQUIRE( fd3.read( inbuffer, 3) );
     REQUIRE( inbuffer == "bob" );
-    Kit::Io::ByteCount_T len;
+    Kit::Type::SSize_T len;
     REQUIRE( fd3.length(len) );
     REQUIRE( len == sum.length());
     fd3.close();

--- a/src/Kit/Io/File/_0test/write.cpp
+++ b/src/Kit/Io/File/_0test/write.cpp
@@ -117,12 +117,12 @@ TEST_CASE( "write/close")
     fd.flush();
     
     REQUIRE( fd.isEof() == true );
-    Kit::Io::ByteCount_T pos;
+    Kit::Type::SSize_T pos;
     REQUIRE( fd.currentPos( pos ) == false );
     REQUIRE( fd.setAbsolutePos( 1 ) == false );
     REQUIRE( fd.setRelativePos( 1 ) == false );
     REQUIRE( fd.setToEof() == false );
-    Kit::Io::ByteCount_T len = 22;
+    Kit::Type::SSize_T len = 22;
     REQUIRE( fd.length( len ) == false );
 
 

--- a/src/Kit/Io/IInput.cpp
+++ b/src/Kit/Io/IInput.cpp
@@ -21,7 +21,7 @@ namespace Io {
 ///////////////////
 bool IInput::read( char& c ) noexcept
 {
-    ByteCount_T bytesRead = 0;
+    Kit::Type::SSize_T bytesRead = 0;
     bool        result    = true;
     do
     {
@@ -34,23 +34,23 @@ bool IInput::read( char& c ) noexcept
 
 bool IInput::read( Kit::Text::IString& destString ) noexcept
 {
-    ByteCount_T bytesRead = 0;
+    Kit::Type::SSize_T bytesRead = 0;
     int         maxlen    = 0;
     char*       buffer    = destString.getBuffer( maxlen );
-    ByteCount_T len       = static_cast<ByteCount_T>( maxlen );
+    Kit::Type::SSize_T len       = static_cast<Kit::Type::SSize_T>( maxlen );
     bool        result    = read( buffer, len, bytesRead );
     buffer[bytesRead]     = '\0';
     return result;
 }
 
-bool IInput::read( Kit::Text::IString& destString, ByteCount_T numBytesToRead ) noexcept
+bool IInput::read( Kit::Text::IString& destString, Kit::Type::SSize_T numBytesToRead ) noexcept
 {
     KIT_SYSTEM_ASSERT( numBytesToRead >= 0 );
 
     // Housekeeping
     int         maxlen = 0;
     char*       buffer = destString.getBuffer( maxlen );
-    ByteCount_T len    = static_cast<ByteCount_T>( maxlen );
+    Kit::Type::SSize_T len    = static_cast<Kit::Type::SSize_T>( maxlen );
     if ( numBytesToRead > len )
     {
         numBytesToRead = len;  // Limit numBytesToRead to max allowed length of the string
@@ -63,7 +63,7 @@ bool IInput::read( Kit::Text::IString& destString, ByteCount_T numBytesToRead ) 
     return result;
 }
 
-bool IInput::read( void* buffer, ByteCount_T numBytesToRead ) noexcept
+bool IInput::read( void* buffer, Kit::Type::SSize_T numBytesToRead ) noexcept
 {
     KIT_SYSTEM_ASSERT( buffer != nullptr );
     KIT_SYSTEM_ASSERT( numBytesToRead >= 0 );
@@ -72,8 +72,8 @@ bool IInput::read( void* buffer, ByteCount_T numBytesToRead ) noexcept
     if ( numBytesToRead > 0 )
     {
         // Housekeeping
-        ByteCount_T bytesRead = 0;
-        ByteCount_T remaining = numBytesToRead;
+        Kit::Type::SSize_T bytesRead = 0;
+        Kit::Type::SSize_T remaining = numBytesToRead;
         auto*       ptr       = static_cast<uint8_t*>( buffer );
 
         // Keep reading until all requested bytes are read

--- a/src/Kit/Io/IInput.h
+++ b/src/Kit/Io/IInput.h
@@ -61,7 +61,7 @@ public:
 
         If the method fails, the contents of the 'destString' is undefined.
      */
-    virtual bool read( Kit::Text::IString& destString, ByteCount_T numBytesToRead ) noexcept;
+    virtual bool read( Kit::Text::IString& destString, Kit::Type::SSize_T numBytesToRead ) noexcept;
 
     /** Attempts to read the specified number of bytes from the stream in the
         supplied buffer.  The actual number of bytes read is returned via
@@ -73,14 +73,14 @@ public:
         The caller is responsible for providing a buffer that is large
         enough to hold the requested number of bytes.
      */
-    virtual bool read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept = 0;
+    virtual bool read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept = 0;
 
-    /** This method is similar to read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ),
+    /** This method is similar to read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ),
         except that it will NOT return until 'numBytesToRead' have been read.
         
         If the method fails, the contents of the 'buffer' is undefined.
      */
-    virtual bool read( void* buffer, ByteCount_T numBytesToRead ) noexcept;
+    virtual bool read( void* buffer, Kit::Type::SSize_T numBytesToRead ) noexcept;
 
     /** Returns true if there data available to be read from the stream.
 

--- a/src/Kit/Io/IOutput.cpp
+++ b/src/Kit/Io/IOutput.cpp
@@ -22,7 +22,7 @@ namespace Io {
 bool IOutput::write( char c ) noexcept
 {
     auto*       ptr      = static_cast<const void*>( &c );
-    ByteCount_T numBytes = sizeof( c );
+    Kit::Type::SSize_T numBytes = sizeof( c );
     return write( ptr, numBytes );
 }
 
@@ -31,14 +31,14 @@ bool IOutput::write( const char* string ) noexcept
 {
     KIT_SYSTEM_ASSERT( string != nullptr );
 
-    ByteCount_T numBytes = strlen( string );
+    Kit::Type::SSize_T numBytes = strlen( string );
     return write( string, numBytes );
 }
 
 
 bool IOutput::write( const Kit::Text::IString& string ) noexcept
 {
-    ByteCount_T numBytes = string.length();
+    Kit::Type::SSize_T numBytes = string.length();
     return write( string(), numBytes );
 }
 
@@ -59,16 +59,16 @@ bool IOutput::vwrite( Kit::Text::IString& formatBuffer, const char* format, va_l
     KIT_SYSTEM_ASSERT( format != nullptr );
 
     formatBuffer.vformat( format, ap );
-    ByteCount_T numBytes = formatBuffer.length();
+    Kit::Type::SSize_T numBytes = formatBuffer.length();
     return write( formatBuffer(), numBytes );
 }
 
-bool IOutput::write( const void* buffer, ByteCount_T numBytes ) noexcept
+bool IOutput::write( const void* buffer, Kit::Type::SSize_T numBytes ) noexcept
 {
     KIT_SYSTEM_ASSERT( buffer != nullptr );
     KIT_SYSTEM_ASSERT( numBytes >= 0 );
     
-    ByteCount_T written = 0;
+    Kit::Type::SSize_T written = 0;
     auto*       ptr     = static_cast<const uint8_t*>( buffer );
 
     // Loop until all data is written

--- a/src/Kit/Io/IOutput.h
+++ b/src/Kit/Io/IOutput.h
@@ -77,14 +77,14 @@ public:
         successful, or false if End-of-Stream as encountered. The method does
         not return until 'numBytes' have been written to the Output stream.
      */
-    virtual bool write( const void* buffer, ByteCount_T numBytes ) noexcept;
+    virtual bool write( const void* buffer, Kit::Type::SSize_T numBytes ) noexcept;
 
     /** Writes the content of the buffer to the stream. At most 'maxBytes'
         will be outputted.  The actual number of bytes written is returned
         via 'bytesWritten'. Returns true if successful, or false if End-of-Stream
         was encountered.
      */
-    virtual bool write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept = 0;
+    virtual bool write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept = 0;
 
     /** Forces all buffered data (if any) to be written to the stream media.
         The actual behavior of this method for how/when the data is flushed -

--- a/src/Kit/Io/Null.cpp
+++ b/src/Kit/Io/Null.cpp
@@ -22,7 +22,7 @@ namespace Io {
 }
 
 /////////////////////
-bool Null::read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept 
+bool Null::read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept 
 {
     KIT_SYSTEM_ASSERT( buffer != nullptr );
 
@@ -36,7 +36,7 @@ bool Null::available() noexcept
     return false;
 }
 
-bool Null::write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept 
+bool Null::write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept 
 {
     KIT_SYSTEM_ASSERT( buffer != nullptr );
 

--- a/src/Kit/Io/Null.h
+++ b/src/Kit/Io/Null.h
@@ -34,7 +34,7 @@ public:
     using Kit::Io::IInputOutput::read;
 
     /// See Kit::Io::IInput
-    bool read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept override;
+    bool read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept override;
 
     /// See Kit::Io::IInput
     bool available() noexcept override;
@@ -45,7 +45,7 @@ public:
     using Kit::Io::IInputOutput::write;
 
     /// See Kit::Io::IOutput
-    bool write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept override;
+    bool write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept override;
 
     /// See Kit::Io::IOutput
     void flush() noexcept override;

--- a/src/Kit/Io/Ram/InputOutput.cpp
+++ b/src/Kit/Io/Ram/InputOutput.cpp
@@ -1,0 +1,190 @@
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "InputOutput.h"
+
+using namespace Kit::System;
+
+//------------------------------------------------------------------------------
+namespace Kit {
+namespace Io {
+namespace Ram {
+
+
+////////////////////////////////////
+bool InputOutput::available() noexcept
+{
+    if ( !m_started )
+    {
+        return false;
+    }
+    Mutex::ScopeLock criticalSection( m_lock );
+    return m_ringBuffer.isEmpty() == false;
+}
+
+bool InputOutput::read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept
+{
+    // Skip if no data was requested
+    bytesRead = 0;
+    if ( numBytes == 0 )
+    {
+        return true;
+    }
+
+    if ( !m_started )
+    {
+        return false;
+    }
+
+    // Loop until at least one byte is read or the stream is closed
+    for ( ; m_started; )
+    {
+        // Scope block is used to limit the critical section to just the peek/remove operations on the ring buffer
+        {
+            Mutex::ScopeLock criticalSection( m_lock );
+
+            // Determine how much data is currently available in the ring buffer AS A SEQUENTIAL read
+            unsigned numFlatBytesAvailable = 0;
+            uint8_t* srcPtr                = m_ringBuffer.peekNextRemoveItems( numFlatBytesAvailable );
+
+            // At least one byte is available -->fullfill the read request with the available data.
+            if ( numFlatBytesAvailable != 0 )
+            {
+                // Copy the lesser of the requested bytes and the available bytes to the client buffer
+                unsigned numBytesToRead = static_cast<unsigned>( numBytes ) < numFlatBytesAvailable ? static_cast<unsigned>( numBytes ) : numFlatBytesAvailable;
+                memcpy( buffer, srcPtr, numBytesToRead );
+                bytesRead = numBytesToRead;
+
+                // Remove the data from the buffer
+                m_ringBuffer.removeElements( static_cast<unsigned>( numBytesToRead ) );
+
+                // Unblock the waiting writer (if any)
+                if ( m_writerWaiting )
+                {
+                    m_writerWaiting = false;
+                    m_semaWriter.signal();
+                }
+                return true;
+            }
+            else
+            {
+                // No data is currently available -->I will block until data is available
+                m_readerWaiting = true;
+            }
+        }
+
+        // No data available
+        m_semaReader.wait();
+    }
+
+    // If get here, then stream was closed while I was waiting for data -->return false
+    bytesRead = 0;
+    return false;
+}
+
+bool InputOutput::write( const void* buffer, Kit::Type::SSize_T numBytesToTx, Kit::Type::SSize_T& bytesWritten ) noexcept
+{
+    // Ignore write of zero bytes
+    bytesWritten = 0;
+    if ( numBytesToTx == 0 )
+    {
+        return true;
+    }
+
+    // Fail if not started
+    if ( !m_started )
+    {
+        return false;
+    }
+
+
+    // Loop until at least one byte has been transferred OR the stream is closed
+    for ( ; m_started; )
+    {
+        // Scope block is used to limit the critical section to just the peek/insert operations on the ring buffer
+        {
+            Mutex::ScopeLock criticalSection( m_lock );
+
+            // Determine how much space is currently available in the ring buffer AS A SEQUENTIAL write
+            unsigned numFlatBytesAvailable = 0;
+            uint8_t* dstPtr                = m_ringBuffer.peekNextAddItems( numFlatBytesAvailable );
+
+            // At least one byte is available -->fullfill the write request with the available space.
+            if ( numFlatBytesAvailable != 0 )
+            {
+                // Copy the lesser of the requested bytes and the available bytes to the client buffer
+                unsigned numBytesToWrite = static_cast<unsigned>( numBytesToTx ) < numFlatBytesAvailable ? static_cast<unsigned>( numBytesToTx ) : numFlatBytesAvailable;
+                memcpy( dstPtr, buffer, numBytesToWrite );
+                bytesWritten = numBytesToWrite;
+
+                // Add the data to the buffer
+                m_ringBuffer.addElements( static_cast<unsigned>( numBytesToWrite ) );
+
+                // Unblock the waiting reader (if any)
+                if ( m_readerWaiting )
+                {
+                    m_readerWaiting = false;
+                    m_semaReader.signal();
+                }
+                return true;
+            }
+            else
+            {
+                // No space is currently available
+                m_writerWaiting = true;
+            }
+        }
+
+        // No space available -->block until space is available
+        m_semaWriter.wait();
+    }
+
+    // If get here, then stream was closed while I was waiting for space -->return false
+    bytesWritten = 0;
+    return false;
+}
+
+
+void InputOutput::flush() noexcept
+{
+    // Has no meaning
+}
+
+bool InputOutput::isEos() noexcept
+{
+    // Has no meaning, always return false except when closed -->then return true
+    return m_started == false;
+}
+
+void InputOutput::close() noexcept
+{
+    // By design, no explicit critical section is used.  Instead leveraging the
+    // the 'atomic' nature of volatile bool variables to avoid potential deadlock
+    // scenarios with the m_lock mutex
+
+    // Only take action if I am not already closed.
+    if ( m_started )
+    {
+        m_started = false;
+        if ( m_readerWaiting )
+        {
+            m_semaReader.signal();
+        }
+        if ( m_writerWaiting )
+        {
+            m_semaWriter.signal();
+        }
+    }
+}
+
+}  // end namespace
+}
+}
+//------------------------------------------------------------------------------

--- a/src/Kit/Io/Ram/InputOutput.cpp
+++ b/src/Kit/Io/Ram/InputOutput.cpp
@@ -9,6 +9,7 @@
 /** @file */
 
 #include "InputOutput.h"
+#include <string.h>
 
 using namespace Kit::System;
 

--- a/src/Kit/Io/Ram/InputOutput.h
+++ b/src/Kit/Io/Ram/InputOutput.h
@@ -52,6 +52,12 @@ public:
     {
     }
 
+    /// Destructor
+    ~InputOutput() noexcept
+    {
+        close();
+    }
+    
 public:
     /// Pull in overloaded methods from base class
     using Kit::Io::IInputOutput::read;

--- a/src/Kit/Io/Ram/InputOutput.h
+++ b/src/Kit/Io/Ram/InputOutput.h
@@ -1,0 +1,107 @@
+#ifndef KIT_IO_RAM_INPUTOUTPUT_H_
+#define KIT_IO_RAM_INPUTOUTPUT_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Io/IInputOutput.h"
+#include "Kit/Container/RingBuffer.h"
+#include "Kit/System/Semaphore.h"
+#include "Kit/System/Mutex.h"
+
+///
+namespace Kit {
+///
+namespace Io {
+///
+namespace Ram {
+
+/** This concrete class implements an InputOutput stream using a Ring
+    Buffer.
+
+    NOTES:
+    - Thread safe and read and write operations have blocking semantics when
+      the RingBuffer is empty or full, respectively.
+    - For concurrent access, there can only be at a single ACTIVE reader and a
+      single ACTIVE writer of the stream. In addition, the concurrent active
+      reader/writer must be in different threads.  For serialized access there
+      is no threading restrictions on the readers and writers.
+    - This is NOT shared memory across processes, i.e. assumes a SINGLE
+      address space.
+    - Implementation is not necessarily efficient - it is more focused on
+      clarity and robustness.
+ */
+
+class InputOutput : public Kit::Io::IInputOutput
+{
+public:
+    /** Constructor. 'N' is the number of bytes in 'memoryBuffer'. The actual
+        number of bytes that can be stored in the Ring Buffer is N-1.
+     */
+    InputOutput( uint8_t* memoryBuffer, unsigned N, bool initializeMemory = true  ) noexcept
+        : m_ringBuffer( memoryBuffer, N, initializeMemory )
+        , m_readerWaiting( false )
+        , m_writerWaiting( false )
+        , m_started( true )
+    {
+    }
+
+public:
+    /// Pull in overloaded methods from base class
+    using Kit::Io::IInputOutput::read;
+
+    /// See Kit::Io::IInput
+    bool read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept override;
+
+    /// See Kit::Io::IInput
+    bool available() noexcept override;
+
+public:
+    /// Pull in overloaded methods from base class
+    using Kit::Io::IInputOutput::write;
+
+    /// See Kit::Io::IOutput
+    bool write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept override;
+
+    /// See Kit::Io::IOutput
+    void flush() noexcept override;
+
+    /// See Kit::Io::IEos. Note: This method always returns false
+    bool isEos() noexcept override;
+
+    /// See Kit::Io::IOutput
+    void close() noexcept override;
+
+protected:
+    /// Thread safe Ring buffer
+    Kit::Container::RingBuffer<uint8_t> m_ringBuffer;
+
+    /// Blocking read semantics when the RingBuffer is empty
+    Kit::System::Semaphore m_semaReader;
+
+    /// Blocking write semantics when the RingBuffer is full
+    Kit::System::Semaphore m_semaWriter;
+
+    /// Mutex to protect concurrent access to the RingBuffer
+    Kit::System::Mutex m_lock;
+
+    /// Track if there is blocked reader (NOTE: Not Protected by m_lock)
+    volatile bool m_readerWaiting;
+
+    /// Track if there is blocked writer (NOTE: Not Protected by m_lock)
+    volatile bool m_writerWaiting;
+
+    /// My open/close state (NOTE: Not Protected by m_lock)
+    volatile bool m_started;
+};
+
+}  // end namespaces
+}
+}
+#endif  // end header latch

--- a/src/Kit/Io/Ram/InputOutput.h
+++ b/src/Kit/Io/Ram/InputOutput.h
@@ -97,13 +97,13 @@ protected:
     /// Mutex to protect concurrent access to the RingBuffer
     Kit::System::Mutex m_lock;
 
-    /// Track if there is blocked reader (NOTE: Not Protected by m_lock)
+    /// Track if there is blocked reader (NOTE: Not Protected by m_lock - assumes reading/writing a bool is atomic on the target platform)
     volatile bool m_readerWaiting;
 
-    /// Track if there is blocked writer (NOTE: Not Protected by m_lock)
+    /// Track if there is blocked writer (NOTE: Not Protected by m_lock - assumes reading/writing a bool is atomic on the target platform)
     volatile bool m_writerWaiting;
 
-    /// My open/close state (NOTE: Not Protected by m_lock)
+    /// My open/close state (NOTE: Not Protected by m_lock - assumes reading/writing a bool is atomic on the target platform)
     volatile bool m_started;
 };
 

--- a/src/Kit/Io/Ram/InputOutputAllocate.h
+++ b/src/Kit/Io/Ram/InputOutputAllocate.h
@@ -20,7 +20,7 @@ namespace Io {
 ///
 namespace Ram {
 
-/** This concrete template convience class extends the RAM InputOutput class
+/** This concrete template convenience class extends the RAM InputOutput class
     to include allocating the Ring Buffer memory.  The template argument 
     'NUM_BYTES' is the number of 'useable' bytes.
  */

--- a/src/Kit/Io/Ram/InputOutputAllocate.h
+++ b/src/Kit/Io/Ram/InputOutputAllocate.h
@@ -1,0 +1,45 @@
+#ifndef KIT_IO_RAM_INPUTOUTPUTALLOCATE_H_
+#define KIT_IO_RAM_INPUTOUTPUTALLOCATE_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "Kit/Io/Ram/InputOutput.h"
+#include "Kit/Container/RingBufferAllocate.h"
+
+///
+namespace Kit {
+///
+namespace Io {
+///
+namespace Ram {
+
+/** This concrete template convience class extends the RAM InputOutput class
+    to include allocating the Ring Buffer memory.  The template argument 
+    'NUM_BYTES' is the number of 'useable' bytes.
+ */
+template <int NUM_BYTES>
+class InputOutputAllocate : public InputOutput
+{
+public:
+    /// Constructor.
+    InputOutputAllocate() noexcept
+        : InputOutput( m_memory, sizeof(m_memory) )
+    {
+    }
+
+protected:
+    /// Memory for the Ring buffer (+1 because the Ring Buffer can only store N-1 bytes when the buffer size is N)
+    uint8_t m_memory[NUM_BYTES+1];   
+};
+
+}  // end namespaces
+}
+}
+#endif  // end header latch

--- a/src/Kit/Io/Ram/README.md
+++ b/src/Kit/Io/Ram/README.md
@@ -1,0 +1,6 @@
+# Kit::Io::Ram
+@brief namespace description for Kit::Io::Ram
+@namespace Kit::Io::Ram @brief
+
+The Ram namespace implements the Kit::Io stream interfaces using RAM as the
+stream media

--- a/src/Kit/Io/Ram/_0test/_0build/.gitignore
+++ b/src/Kit/Io/Ram/_0test/_0build/.gitignore
@@ -1,0 +1,30 @@
+# Misc
+.html-report/
+.coverage.info
+cobertura.json
+jenkins-gcovr.xml
+*.gcov
+_posix64/
+_posix/
+_win32/
+_win64/
+_stm32/
+_arduino/
+ratt.log*
+
+# more stuff
+make.log
+*.gcda
+*.gcno
+*.idb
+*.pdb
+*.ilk
+*.lst
+*.map
+
+# visual studio
+*.ilk
+*.pdb
+*.sln
+
+*.user

--- a/src/Kit/Io/Ram/_0test/_0build/libdirs.b
+++ b/src/Kit/Io/Ram/_0test/_0build/libdirs.b
@@ -1,0 +1,12 @@
+src/Kit/Io/Ram
+src/Kit/Io/Ram/_0test
+
+src/Kit/Io
+src/Kit/System
+src/Kit/Container
+src/Kit/Text
+src/Kit/System/_trace
+src/Kit/System/_trace/_stdout
+
+src/Kit/System/_testsupport
+src/Kit/Memory/_testsupport

--- a/src/Kit/Io/Ram/_0test/_0build/linux/gcc-host/build_catch2.py
+++ b/src/Kit/Io/Ram/_0test/_0build/linux/gcc-host/build_catch2.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python3
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Get the xpackage root directory from environment variable
+    xpackage_root  = os.environ.get('NQBP_XPKGS_ROOT')
+
+    # Run the "real" script
+    script = os.path.join( xpackage_root, "nqbp2", "other", "compile_catch2_base.py" )
+    cmd = script + " " + " ".join(sys.argv[1:])
+    rc = os.system( cmd )
+    sys.exit( rc )

--- a/src/Kit/Io/Ram/_0test/_0build/linux/gcc-host/kit_config.h
+++ b/src/Kit/Io/Ram/_0test/_0build/linux/gcc-host/kit_config.h
@@ -1,0 +1,16 @@
+#ifndef KIT_CONFIG_H_
+#define KIT_CONFIG_H_
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Options' (see LConfig Pattern) */
+
+#define USE_KIT_SYSTEM_TRACE
+#define USE_KIT_SYSTEM_ASSERT
+#define KitTextToStringMaxUnsigned_T uint64_t
+#endif

--- a/src/Kit/Io/Ram/_0test/_0build/linux/gcc-host/kit_map.h
+++ b/src/Kit/Io/Ram/_0test/_0build/linux/gcc-host/kit_map.h
@@ -1,0 +1,22 @@
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Mappings'  
+
+          Note: Intentionally there is NO Header latch (see LHeader Pattern)
+                for why.
+*/
+
+// IO mappings
+#include "Kit/Io/_mappings/_posix/mappings.h"
+
+// OSAL mappings
+#include "Kit/System/Posix/mappings.h"
+
+// strapi mapping
+#include "Kit/Text/_mappings/_posix/strapi.h"

--- a/src/Kit/Io/Ram/_0test/_0build/linux/gcc-host/libdirs.b
+++ b/src/Kit/Io/Ram/_0test/_0build/linux/gcc-host/libdirs.b
@@ -1,0 +1,3 @@
+# Use common (across compilers) libdirs.b
+../libdirs.b
+../../libdirs.b

--- a/src/Kit/Io/Ram/_0test/_0build/linux/gcc-host/mytoolchain.py
+++ b/src/Kit/Io/Ram/_0test/_0build/linux/gcc-host/mytoolchain.py
@@ -1,0 +1,124 @@
+#---------------------------------------------------------------------------
+# This python module is used to customize a supported toolchain for your 
+# project specific settings.
+#
+# Notes:
+#    - ONLY edit/add statements in the sections marked by BEGIN/END EDITS
+#      markers.
+#    - Maintain indentation level and use spaces (it's a python thing) 
+#    - rvalues must be enclosed in quotes (single ' ' or double " ")
+#    - The structure/class 'BuildValues' contains (at a minimum the
+#      following data members.  Any member not specifically set defaults
+#      to null/empty string
+#            .inc             # C/C++ search path include directories 
+#            .asminc          # Assembly search path include directories
+#            .c_only_flags    # C only compiler flags
+#            .cflags          # C and C++ compiler flags
+#            .cppflags        # C++ only compiler flags
+#            .asmflags        # Assembly compiler flags
+#            .linkflags       # Linker flags
+#            .linklibs        # Linker libraries
+#            .firstobjs       # Object files to be unconditionally linked first
+#            .lastobjs        # Object files to be unconditionally linked last
+#           
+#---------------------------------------------------------------------------
+
+# get definition of the Options structure
+from nqbplib.base import BuildValues
+from nqbplib.my_globals import *
+from nqbplib.utils import config_catch2
+import os
+
+# Capture project/build directory
+prjdir = os.path.dirname(os.path.abspath(__file__))
+
+
+#===================================================
+# BEGIN EDITS/CUSTOMIZATIONS
+#---------------------------------------------------
+
+# Set the name for the final output item
+FINAL_OUTPUT_NAME = 'a.out'
+
+# Using Catch2
+(catch2_inc, catch2_lib, unit_test_objects) = config_catch2( prjdir, 'linux/gcc-host', 'a' )
+
+
+# 
+# For build config/variant: "posix64" 
+#
+
+# Construct option structs
+base_posix64      = BuildValues()
+optimized_posix64 = BuildValues()
+debug_posix64     = BuildValues()
+
+# Set project specific 'base' (i.e always used) options. Note: Catch2 requires C++17 or newer
+base_posix64.cflags    = '-m64 -std=c++17 -Wall -Werror -x c++ -fprofile-arcs -ftest-coverage -fprofile-update=atomic'
+base_posix64.inc       = catch2_inc
+base_posix64.firstobjs = unit_test_objects
+base_posix64.linkflags = '-m64 -fprofile-arcs'
+base_posix64.linklibs  = f'-lgcov {catch2_lib}'
+
+# Set project specific 'optimized' options
+optimized_posix64.cflags    = '-O3'
+
+# Set project specific 'debug' options
+
+
+#
+# For build config/variant: "posix32"
+#
+
+# Set project specific 'base' (i.e always used) options. Note: Catch2 requires C++17 or newer
+base_posix32           = BuildValues()        # Do NOT comment out this line
+base_posix32.cflags    = '-m32 -std=c++17 -Wall -Werror -x c++ -fprofile-arcs -ftest-coverage -fprofile-update=atomic'
+base_posix32.inc       = catch2_inc
+base_posix32.firstobjs = unit_test_objects
+base_posix32.linkflags = '-m32 -fprofile-arcs'
+base_posix32.linklibs  = f'-lgcov {catch2_lib}'
+
+
+# Set project specific 'optimized' options
+optimized_posix32           = BuildValues()    # Do NOT comment out this line
+optimized_posix32.cflags    = '-O3'
+
+# Set project specific 'debug' options
+debug_posix32           = BuildValues()       # Do NOT comment out this line
+
+
+
+#-------------------------------------------------
+# ONLY edit this section if you are have more than
+# ONE build configuration/variant 
+#-------------------------------------------------
+
+posix32_opts = { 'user_base':base_posix32, 
+                 'user_optimized':optimized_posix32, 
+                 'user_debug':debug_posix32
+               }
+               
+               
+posix64_opts = { 'user_base':base_posix64, 
+                 'user_optimized':optimized_posix64, 
+                 'user_debug':debug_posix64
+               }
+  
+        
+# Add new variant option dictionary to # dictionary of 
+# build variants
+build_variants = { 'posix':posix32_opts,
+                   'posix64':posix64_opts,
+                 }    
+
+#---------------------------------------------------
+# END EDITS/CUSTOMIZATIONS
+#===================================================
+
+# Select Module that contains the desired toolchain
+from nqbplib.toolchains.linux.gcc.console_exe import ToolChain
+
+# Function that instantiates an instance of the toolchain
+def create():
+    tc = ToolChain( FINAL_OUTPUT_NAME, prjdir, build_variants, "posix64" )
+    return tc 

--- a/src/Kit/Io/Ram/_0test/_0build/linux/gcc-host/nqbp.py
+++ b/src/Kit/Io/Ram/_0test/_0build/linux/gcc-host/nqbp.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+"""Invokes NQBP's mk.py script"""
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Make sure the environment is properly set
+    NQBP_BIN = os.environ.get('NQBP_BIN')
+    if ( NQBP_BIN is None ):
+        sys.exit( "ERROR: The environment variable NQBP_BIN is not set!" )
+    sys.path.append( NQBP_BIN )
+
+    # Find the Package & Workspace root
+    from nqbplib import utils
+    utils.set_pkg_and_wrkspace_roots(__file__)
+
+    # Call into core/common scripts
+    import mytoolchain
+    from nqbplib import mk
+    mk.build( sys.argv, mytoolchain.create() )
+

--- a/src/Kit/Io/Ram/_0test/_0build/linux/gcc-host/sources.b
+++ b/src/Kit/Io/Ram/_0test/_0build/linux/gcc-host/sources.b
@@ -1,0 +1,2 @@
+# share a common main
+../../main.cpp

--- a/src/Kit/Io/Ram/_0test/_0build/linux/gcc-host/tca2.py
+++ b/src/Kit/Io/Ram/_0test/_0build/linux/gcc-host/tca2.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python3
+"""Invokes NQBP's tca2_base.py script.  To run 'TCA2' copy this file to your build directory and the execute it."""
+
+from __future__ import absolute_import
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Make sure the environment is properly set
+    NQBP_BIN = os.environ.get('NQBP_BIN')
+    if ( NQBP_BIN is None ):
+        sys.exit( "ERROR: The environment variable NQBP_BIN is not set!" )
+    sys.path.append( NQBP_BIN )
+
+    # Find the Package & Workspace root
+    from nqbplib import utils
+    utils.set_pkg_and_wrkspace_roots(__file__)
+    here = os.path.dirname(os.path.abspath(__file__))
+
+    # Find the Package & Workspace root
+    from other import tca2_base
+    tca2_base.run( here, sys.argv )
+

--- a/src/Kit/Io/Ram/_0test/_0build/linux/libdirs.b
+++ b/src/Kit/Io/Ram/_0test/_0build/linux/libdirs.b
@@ -1,0 +1,7 @@
+# Platform
+src/Kit/System/Posix
+src/Kit/System/Posix/_fatalerror
+src/Kit/Text/_mappings/_posix
+src/Kit/System/Posix/_realtime
+
+src/Kit/Io/Stdio/Posix

--- a/src/Kit/Io/Ram/_0test/_0build/main.cpp
+++ b/src/Kit/Io/Ram/_0test/_0build/main.cpp
@@ -1,0 +1,18 @@
+#include "Kit/System/Api.h"
+#include "Kit/System/Trace.h"
+#include "catch2/catch_session.hpp"
+
+int main( int argc, char* argv[] )
+{
+    // Initialize KIT Library
+    Kit::System::initialize();
+
+    // Enable trace
+    KIT_SYSTEM_TRACE_ENABLE();
+    KIT_SYSTEM_TRACE_ENABLE_SECTION( "_0test" );
+    KIT_SYSTEM_TRACE_ENABLE_SECTION( "*LOG_" );
+    KIT_SYSTEM_TRACE_SET_INFO_LEVEL( Kit::System::Trace::eVERBOSE );
+
+    // Run the test(s)
+    return Catch::Session().run( argc, argv );
+}

--- a/src/Kit/Io/Ram/_0test/_0build/windows/clang-host/build_catch2.py
+++ b/src/Kit/Io/Ram/_0test/_0build/windows/clang-host/build_catch2.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python3
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Get the xpackage root directory from environment variable
+    xpackage_root  = os.environ.get('NQBP_XPKGS_ROOT')
+
+    # Run the "real" script
+    script = os.path.join( xpackage_root, "nqbp2", "other", "compile_catch2_base.py" )
+    cmd = script + " " + " ".join(sys.argv[1:])
+    rc = os.system( cmd )
+    sys.exit( rc )

--- a/src/Kit/Io/Ram/_0test/_0build/windows/clang-host/kit_config.h
+++ b/src/Kit/Io/Ram/_0test/_0build/windows/clang-host/kit_config.h
@@ -1,0 +1,17 @@
+#ifndef KIT_CONFIG_H_
+#define KIT_CONFIG_H_
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Options' (see LConfig Pattern) */
+
+#define USE_KIT_SYSTEM_TRACE
+#define USE_KIT_SYSTEM_ASSERT
+#define KitTextToStringMaxUnsigned_T uint64_t
+
+#endif

--- a/src/Kit/Io/Ram/_0test/_0build/windows/clang-host/kit_map.h
+++ b/src/Kit/Io/Ram/_0test/_0build/windows/clang-host/kit_map.h
@@ -1,0 +1,24 @@
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Mappings'  
+
+          Note: Intentionally there is NO Header latch (see LHeader Pattern)
+                for why.
+*/
+
+// IO mapping.  Note: Needs to be include FIRST because of winsock2.h ordering issues
+#include "Kit/Io/_mappings/_win32/mappings.h"
+
+// OSAL mappings
+#include "Kit/System/Win32/mappings.h"
+
+// strapi mapping
+#include "Kit/Text/_mappings/_clang-msvc/strapi.h"
+
+

--- a/src/Kit/Io/Ram/_0test/_0build/windows/clang-host/libdirs.b
+++ b/src/Kit/Io/Ram/_0test/_0build/windows/clang-host/libdirs.b
@@ -1,0 +1,3 @@
+# Use common (across compilers) libdirs.b
+../libdirs.b
+../../libdirs.b

--- a/src/Kit/Io/Ram/_0test/_0build/windows/clang-host/mytoolchain.py
+++ b/src/Kit/Io/Ram/_0test/_0build/windows/clang-host/mytoolchain.py
@@ -1,0 +1,97 @@
+#---------------------------------------------------------------------------
+# This python module is used to customize a supported toolchain for your 
+# project specific settings.
+#
+# Notes:
+#    - ONLY edit/add statements in the sections marked by BEGIN/END EDITS
+#      markers.
+#    - Maintain indentation level and use spaces (it's a python thing) 
+#    - The structure/class 'BuildValues' contains (at a minimum the
+#      following data members.  Any member not specifically set defaults
+#      to null/empty string
+#            .inc             # C/C++ search path include directories 
+#            .asminc          # Assembly search path include directories
+#            .c_only_flags    # C only compiler flags
+#            .cflags          # C and C++ compiler flags
+#            .cppflags        # C++ only compiler flags
+#            .asmflags        # Assembly compiler flags
+#            .linkflags       # Linker flags
+#            .linklibs        # Linker libraries
+#            .firstobjs       # Object files to be unconditionally linked first
+#            .lastobjs        # Object files to be unconditionally linked last
+#           
+#---------------------------------------------------------------------------
+
+# get definition of the Options structure
+from nqbplib.base import BuildValues
+from nqbplib.my_globals import *
+from nqbplib.utils import config_catch2
+import os
+
+# Capture project/build directory
+prjdir = os.path.dirname(os.path.abspath(__file__))
+
+#===================================================
+# BEGIN EDITS/CUSTOMIZATIONS
+#---------------------------------------------------
+
+# Set the name for the final output item
+FINAL_OUTPUT_NAME = 'a.exe'
+
+# Using Catch2 
+(catch2_inc, catch2_lib, unit_test_objects) = config_catch2( prjdir, 'windows/clang-host', 'a' )
+
+
+
+#
+# For build config/variant: "win32"
+#
+
+# Construct option structs
+base_win32      = BuildValues()
+optimized_win32 = BuildValues()
+debug_win32     = BuildValues()
+
+# Set 'base' options
+base_win32.cflags     = '-m32 -std=c++17 -Wall -Werror -x c++ -D_CRT_SECURE_NO_WARNINGS'
+base_win32.inc        = catch2_inc
+base_win32.linkflags  = '-m32'
+base_win32.firstobjs  = unit_test_objects
+base_win32.linklibs   = f'{catch2_lib}'
+
+# Set 'Optimized' options
+optimized_win32.cflags    = '-O3'
+
+# Set 'debug' options
+
+
+
+#-------------------------------------------------
+# ONLY edit this section if you are have more than
+# ONE build configuration/variant 
+#-------------------------------------------------
+
+# Add new dictionary of for new build configuration options
+win32_opts = { 'user_base':base_win32,
+               'user_optimized':optimized_win32,
+               'user_debug':debug_win32
+             }
+
+# Add new variant option dictionary to # dictionary of 
+# build variants
+build_variants = { 'win32':win32_opts,
+                 }
+
+
+#---------------------------------------------------
+# END EDITS/CUSTOMIZATIONS
+#===================================================
+
+# Select Module that contains the desired toolchain
+from nqbplib.toolchains.windows.clang_msvc.console_exe import ToolChain
+
+
+# Function that instantiates an instance of the toolchain
+def create():
+    tc = ToolChain( FINAL_OUTPUT_NAME, prjdir, build_variants, "win32" )
+    return tc 

--- a/src/Kit/Io/Ram/_0test/_0build/windows/clang-host/nqbp.py
+++ b/src/Kit/Io/Ram/_0test/_0build/windows/clang-host/nqbp.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+"""Invokes NQBP's mk.py script"""
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Make sure the environment is properly set
+    NQBP_BIN = os.environ.get('NQBP_BIN')
+    if ( NQBP_BIN is None ):
+        sys.exit( "ERROR: The environment variable NQBP_BIN is not set!" )
+    sys.path.append( NQBP_BIN )
+
+    # Find the Package & Workspace root
+    from nqbplib import utils
+    utils.set_pkg_and_wrkspace_roots(__file__)
+
+    # Call into core/common scripts
+    import mytoolchain
+    from nqbplib import mk
+    mk.build( sys.argv, mytoolchain.create() )
+

--- a/src/Kit/Io/Ram/_0test/_0build/windows/clang-host/sources.b
+++ b/src/Kit/Io/Ram/_0test/_0build/windows/clang-host/sources.b
@@ -1,0 +1,2 @@
+# share a common main
+../../main.cpp

--- a/src/Kit/Io/Ram/_0test/_0build/windows/libdirs.b
+++ b/src/Kit/Io/Ram/_0test/_0build/windows/libdirs.b
@@ -1,0 +1,6 @@
+# Platform
+src/Kit/System/Win32
+src/Kit/System/Win32/_shutdown
+src/Kit/System/Win32/_fatalerror
+src/Kit/Io/Stdio/Win32
+src/Kit/System/Win32/_realtime

--- a/src/Kit/Io/Ram/_0test/_0build/windows/msvc/build_catch2.py
+++ b/src/Kit/Io/Ram/_0test/_0build/windows/msvc/build_catch2.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python3
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Get the xpackage root directory from environment variable
+    xpackage_root  = os.environ.get('NQBP_XPKGS_ROOT')
+
+    # Run the "real" script
+    script = os.path.join( xpackage_root, "nqbp2", "other", "compile_catch2_base.py" )
+    cmd = script + " " + " ".join(sys.argv[1:])
+    rc = os.system( cmd )
+    sys.exit( rc )

--- a/src/Kit/Io/Ram/_0test/_0build/windows/msvc/kit_config.h
+++ b/src/Kit/Io/Ram/_0test/_0build/windows/msvc/kit_config.h
@@ -1,0 +1,17 @@
+#ifndef KIT_CONFIG_H_
+#define KIT_CONFIG_H_
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Options' (see LConfig Pattern) */
+
+#define USE_KIT_SYSTEM_TRACE
+#define USE_KIT_SYSTEM_ASSERT
+#define KitTextToStringMaxUnsigned_T uint64_t
+
+#endif

--- a/src/Kit/Io/Ram/_0test/_0build/windows/msvc/kit_map.h
+++ b/src/Kit/Io/Ram/_0test/_0build/windows/msvc/kit_map.h
@@ -1,0 +1,22 @@
+/*-----------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file Project/build specific 'Mappings'  
+
+          Note: Intentionally there is NO Header latch (see LHeader Pattern)
+                for why.
+*/
+
+// IO mapping.  Note: Needs to be include FIRST because of winsock2.h ordering issues
+#include "Kit/Io/_mappings/_win32/mappings.h"
+
+// OSAL mappings
+#include "Kit/System/Win32/mappings.h"
+
+// strapi mapping
+#include "Kit/Text/_mappings/_msvc/strapi.h"

--- a/src/Kit/Io/Ram/_0test/_0build/windows/msvc/libdirs.b
+++ b/src/Kit/Io/Ram/_0test/_0build/windows/msvc/libdirs.b
@@ -1,0 +1,3 @@
+# Use common (across compilers) libdirs.b
+../libdirs.b
+../../libdirs.b

--- a/src/Kit/Io/Ram/_0test/_0build/windows/msvc/mytoolchain.py
+++ b/src/Kit/Io/Ram/_0test/_0build/windows/msvc/mytoolchain.py
@@ -1,0 +1,91 @@
+#---------------------------------------------------------------------------
+# This python module is used to customize a supported toolchain for your 
+# project specific settings.
+#
+# Notes:
+#    - ONLY edit/add statements in the sections marked by BEGIN/END EDITS
+#      markers.
+#    - Maintain indentation level and use spaces (it's a python thing) 
+#    - The structure/class 'BuildValues' contains (at a minimum the
+#      following data members.  Any member not specifically set defaults
+#      to null/empty string
+#            .inc             # C/C++ search path include directories 
+#            .asminc          # Assembly search path include directories
+#            .c_only_flags    # C only compiler flags
+#            .cflags          # C and C++ compiler flags
+#            .cppflags        # C++ only compiler flags
+#            .asmflags        # Assembly compiler flags
+#            .linkflags       # Linker flags
+#            .linklibs        # Linker libraries
+#            .firstobjs       # Object files to be unconditionally linked first
+#            .lastobjs        # Object files to be unconditionally linked last
+#           
+#---------------------------------------------------------------------------
+
+# get definition of the Options structure
+from nqbplib.base import BuildValues
+from nqbplib.my_globals import *
+from nqbplib.utils import config_catch2
+import os
+
+# Capture project/build directory
+prjdir = os.path.dirname(os.path.abspath(__file__))
+
+#===================================================
+# BEGIN EDITS/CUSTOMIZATIONS
+#---------------------------------------------------
+
+# Set the name for the final output item
+FINAL_OUTPUT_NAME = 'a.exe'
+
+# Using Catch2 
+(catch2_inc, catch2_lib, unit_test_objects) = config_catch2( prjdir, 'windows/msvc', 'lib' )
+
+
+#
+# For build config/variant: "win32" 
+#
+
+# Set project specific 'base' (i.e always used) options. Note: Catch2 requires C++17 or newer
+base_win32           = BuildValues()        # Do NOT comment out this line
+base_win32.cflags    = '/W3 /WX /EHsc '  # /EHsc enables exceptions /std:c++17
+base_win32.firstobjs = unit_test_objects
+base_win32.inc       = catch2_inc
+base_win32.linklibs  = catch2_lib
+
+# Set project specific 'optimized' options
+optimized_win32          = BuildValues()    # Do NOT comment out this line
+optimized_win32.cflags   = '/O2'
+
+# Set project specific 'debug' options
+debug_win32          = BuildValues()       # Do NOT comment out this line
+debug_win32.cflags   = '/D "KIT_DEBUG"'
+
+
+#-------------------------------------------------
+# ONLY edit this section if you are have more than
+# ONE build configuration/variant 
+#-------------------------------------------------
+
+win32_build_opts = { 'user_base':base_win32, 
+                     'user_optimized':optimized_win32, 
+                     'user_debug':debug_win32
+                   }
+               
+# Add new variant option dictionary to # dictionary of 
+# build variants
+build_variants = { 'win32':win32_build_opts,
+                 }    
+
+#---------------------------------------------------
+# END EDITS/CUSTOMIZATIONS
+#===================================================
+
+
+# Select Module that contains the desired toolchain
+from nqbplib.toolchains.windows.vc12.console_exe import ToolChain
+
+# Function that instantiates an instance of the toolchain
+def create():
+    tc = ToolChain( FINAL_OUTPUT_NAME, prjdir, build_variants, 'win32' )
+    return tc 

--- a/src/Kit/Io/Ram/_0test/_0build/windows/msvc/nqbp.py
+++ b/src/Kit/Io/Ram/_0test/_0build/windows/msvc/nqbp.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+"""Invokes NQBP's mk.py script"""
+
+import os
+import sys
+
+# MAIN
+if __name__ == '__main__':
+    # Make sure the environment is properly set
+    NQBP_BIN = os.environ.get('NQBP_BIN')
+    if ( NQBP_BIN is None ):
+        sys.exit( "ERROR: The environment variable NQBP_BIN is not set!" )
+    sys.path.append( NQBP_BIN )
+
+    # Find the Package & Workspace root
+    from nqbplib import utils
+    utils.set_pkg_and_wrkspace_roots(__file__)
+
+    # Call into core/common scripts
+    import mytoolchain
+    from nqbplib import mk
+    mk.build( sys.argv, mytoolchain.create() )
+

--- a/src/Kit/Io/Ram/_0test/_0build/windows/msvc/sources.b
+++ b/src/Kit/Io/Ram/_0test/_0build/windows/msvc/sources.b
@@ -1,0 +1,2 @@
+# share a common main
+../../main.cpp

--- a/src/Kit/Io/Ram/_0test/inputouput.cpp
+++ b/src/Kit/Io/Ram/_0test/inputouput.cpp
@@ -61,13 +61,19 @@ public:
     {
         doneFlag      = false;
         m_doneFlagPtr = &doneFlag;
-        m_parentThreadPtr_->signal();
+        if ( m_parentThreadPtr_ )
+        {
+            m_parentThreadPtr_->signal();
+        }
     }
     ///
     void terminate()
     {
         m_run = false;
-        m_parentThreadPtr_->signal();
+        if ( m_parentThreadPtr_ )
+        {
+            m_parentThreadPtr_->signal();
+        }
     }
 
 public:
@@ -121,13 +127,20 @@ public:
     {
         doneFlag      = false;
         m_doneFlagPtr = &doneFlag;
-        m_parentThreadPtr_->signal();
+        if ( m_parentThreadPtr_ )
+        {
+            m_parentThreadPtr_->signal();
+        }
     }
+
     ///
     void terminate()
     {
         m_run = false;
-        m_parentThreadPtr_->signal();
+        if ( m_parentThreadPtr_ )
+        {
+            m_parentThreadPtr_->signal();
+        }
     }
 public:
     ///

--- a/src/Kit/Io/Ram/_0test/inputouput.cpp
+++ b/src/Kit/Io/Ram/_0test/inputouput.cpp
@@ -1,0 +1,379 @@
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+
+#include "Kit/System/_testsupport/ShutdownUnitTesting.h"
+#include "catch2/catch_test_macros.hpp"
+#include "Kit/_support/testing/helpers.h"
+#include "Kit/System/Api.h"
+#include "Kit/System/Trace.h"
+#include "Kit/System/IRunnable.h"
+#include "Kit/System/Thread.h"
+#include "Kit/Text/FString.h"
+#include "Kit/Io/Ram/InputOutputAllocate.h"
+
+#include <string.h>
+#include <inttypes.h>
+
+
+#define SECT_ "_0test"
+
+///
+using namespace Kit::Io::Ram;
+using namespace Kit::Type;
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Use anonymous namespace to make my class local-to-the-file in scope
+namespace {
+
+///
+class Writer : public Kit::System::IRunnable
+{
+public:
+    bool                   m_success;
+    unsigned               m_writeOperations;
+    const char*            m_stringToWrite;
+    bool                   m_run;
+    bool*                  m_doneFlagPtr;
+    Kit::Io::IInputOutput& m_stream;
+
+public:
+    ///
+    Writer( Kit::Io::IInputOutput& fd, const char* writeString )
+        : m_writeOperations( 0 )
+        , m_stringToWrite( writeString )
+        , m_run( true )
+        , m_doneFlagPtr( 0 )
+        , m_stream( fd ) {}
+
+
+public:
+    ///
+    void startWriting( bool& doneFlag )
+    {
+        doneFlag      = false;
+        m_doneFlagPtr = &doneFlag;
+        m_parentThreadPtr_->signal();
+    }
+    ///
+    void terminate()
+    {
+        m_run = false;
+        m_parentThreadPtr_->signal();
+    }
+
+public:
+    ///
+    void entry() noexcept override
+    {
+        m_success = true;
+        while ( m_run && m_success )
+        {
+            Kit::System::Thread::wait();
+            if ( m_run && m_success )  // check again
+            {
+                m_writeOperations++;
+                m_success = m_stream.write( m_stringToWrite );
+                if ( m_doneFlagPtr )
+                {
+                    *m_doneFlagPtr = true;
+                }
+            }
+        }
+    }
+};
+
+///
+class Reader : public Kit::System::IRunnable
+{
+public:
+    bool                   m_success;
+    unsigned               m_readOperations;
+    char*                  m_dstBuffer;
+    SSize_T                m_bytesToRead;
+    SSize_T                m_bytesRead;
+    bool                   m_run;
+    bool*                  m_doneFlagPtr;
+    Kit::Io::IInputOutput& m_stream;
+
+public:
+    ///
+    Reader( Kit::Io::IInputOutput& fd, char* dst, SSize_T numBytesToRead )
+        : m_readOperations( 0 )
+        , m_dstBuffer( dst )
+        , m_bytesToRead( numBytesToRead )
+        , m_run( true )
+        , m_doneFlagPtr( 0 )
+        , m_stream( fd ) {}
+
+
+public:
+    ///
+    void startReading( bool& doneFlag )
+    {
+        doneFlag      = false;
+        m_doneFlagPtr = &doneFlag;
+        m_parentThreadPtr_->signal();
+    }
+    ///
+    void terminate()
+    {
+        m_run = false;
+        m_parentThreadPtr_->signal();
+    }
+public:
+    ///
+    void entry() noexcept override
+    {
+        m_success = true;
+        while ( m_run && m_success )
+        {
+            Kit::System::Thread::wait();
+            if ( m_run && m_success )  // check again
+            {
+                m_bytesRead            = 0;
+                SSize_T bytesRemaining = m_bytesToRead;
+                SSize_T bytesRead;
+                char    buf[100] = {
+                    0,
+                };
+                memset( m_dstBuffer, 0, m_bytesToRead + 1 );
+                m_readOperations++;
+
+                while ( bytesRemaining )
+                {
+                    if ( !m_stream.read( buf, bytesRemaining, bytesRead ) )
+                    {
+                        m_success = false;
+                        break;
+                    }
+                    strncat( m_dstBuffer, buf, bytesRead );
+                    m_bytesRead    += bytesRead;
+                    bytesRemaining -= bytesRead;
+                }
+
+                if ( m_doneFlagPtr )
+                {
+                    *m_doneFlagPtr = true;
+                }
+            }
+        }
+    }
+};
+
+}  // end anonymous namespace
+
+
+////////////////////////////////////////////////////////////////////////////////
+#define MAX_ELEMENTS 16
+
+#define TEST_STRING1 "hello world"
+#define TEST_STRING2 "I am doing fine"
+#define TEST_STRING3 "That's great"
+
+TEST_CASE( "inputoutput" )
+{
+    KIT_SYSTEM_TRACE_FUNC( SECT_ );
+    Kit::System::ShutdownUnitTesting::clearAndUseCounter();
+    Kit::Text::FString<MAX_ELEMENTS>  tmpString;
+    InputOutputAllocate<MAX_ELEMENTS> uut;
+
+    SECTION( "single threaded" )
+    {
+        bool result = uut.available();
+        REQUIRE( result == false );
+        result = uut.isEos();
+        REQUIRE( result == false );
+
+        result = uut.write( TEST_STRING1 );
+        REQUIRE( result == true );
+        uut.flush(); // Flush should do nothing
+        result = uut.available();
+        REQUIRE( result == true );
+        result = uut.read( tmpString );
+        REQUIRE( result == true );
+
+        // Zero byte read/write should succeed but do nothing
+        SSize_T bytesResult = -1;
+        result = uut.write( (void*)TEST_STRING1, 0, bytesResult );
+        REQUIRE( bytesResult == 0 );
+        REQUIRE( result == true );
+        bytesResult = -1;
+        result = uut.read( (void*)TEST_STRING1, 0, bytesResult );
+        REQUIRE( bytesResult == 0 );
+        REQUIRE( result == true );
+
+        uut.close();
+        result = uut.available();
+        REQUIRE( result == false );
+        result = uut.read( tmpString );
+        REQUIRE( result == false );
+        result = uut.write( TEST_STRING1 );
+        REQUIRE( result == false );
+        result = uut.isEos();
+        REQUIRE( result == true );
+    }
+
+    SECTION( "single writer, single reader" )
+    {
+        Writer writer( uut, TEST_STRING2 );
+        char   reader1Buf[100];
+        Reader reader1( uut, reader1Buf, strlen( TEST_STRING2 ) );
+
+        Kit::System::Thread* w1 = Kit::System::Thread::create( writer, "Writer" );
+        Kit::System::Thread* r1 = Kit::System::Thread::create( reader1, "Reader1" );
+        REQUIRE( waitThreadActive( w1 ) == true );
+        REQUIRE( waitThreadActive( r1 ) == true );
+
+        // Start my readers
+        bool reader1Done;
+        reader1.startReading( reader1Done );
+        Kit::System::sleep( 200 );  // Wait to ensure all reader loops have started
+        REQUIRE( reader1Done == false );
+
+        // Start my write
+        bool writerDone;
+        writer.startWriting( writerDone );
+        Kit::System::sleep( 500 );  // Wait to ensure write is done
+        REQUIRE( writerDone == true );
+        REQUIRE( writer.m_success == true );
+        REQUIRE( writer.m_writeOperations == 1 );
+
+        // Did I read the data?
+        REQUIRE( reader1.m_bytesRead == strlen( TEST_STRING2 ) );
+        REQUIRE( reader1.m_readOperations == 1 );
+
+        // Shutdown the threads
+        writer.terminate();
+        reader1.terminate();
+        uut.close();  // This will unblock all clients
+
+        // Allow time for threads to stop
+        REQUIRE( waitThreadInactive( w1 ) == true );
+        REQUIRE( waitThreadInactive( r1 ) == true );
+
+        Kit::System::Thread::destroy( *w1 );
+        Kit::System::Thread::destroy( *r1 );
+    }
+
+    SECTION( "blocked reader" )
+    {
+        char                 reader1Buf[100];
+        Reader               reader1( uut, reader1Buf, strlen( TEST_STRING2 ) );
+        Kit::System::Thread* r1 = Kit::System::Thread::create( reader1, "Reader1" );
+        REQUIRE( waitThreadActive( r1 ) == true );
+
+        Writer               writer( uut, TEST_STRING2 );
+        Kit::System::Thread* w1 = Kit::System::Thread::create( writer, "Writer" );
+        REQUIRE( waitThreadActive( w1 ) == true );
+
+        // Start my reader (which will block waiting for data)
+        bool reader1Done;
+        reader1.startReading( reader1Done );
+        Kit::System::sleep( 200 );  // Wait to ensure all reader loops have started
+        REQUIRE( reader1Done == false );
+
+        // Start my write
+        bool writerDone;
+        writer.startWriting( writerDone );
+        Kit::System::sleep( 500 );  // Wait to ensure write is done
+        REQUIRE( writerDone == true );
+        REQUIRE( writer.m_success == true );
+        REQUIRE( writer.m_writeOperations == 1 );
+        REQUIRE( reader1.m_bytesRead == strlen( TEST_STRING2 ) );
+        REQUIRE( reader1.m_readOperations == 1 );
+        REQUIRE( reader1Done == true );
+
+        // Start my reader AGAIN (which will block waiting for data)
+        reader1.startReading( reader1Done );
+        Kit::System::sleep( 200 );  // Wait to ensure all reader loops have started
+        REQUIRE( reader1Done == false );
+
+        // Start my write AGAIN
+        writer.startWriting( writerDone );
+        Kit::System::sleep( 500 );  // Wait to ensure write is done
+        REQUIRE( writerDone == true );
+        REQUIRE( writer.m_success == true );
+        REQUIRE( writer.m_writeOperations == 2 );
+        REQUIRE( reader1.m_bytesRead == strlen( TEST_STRING2 ) );
+        REQUIRE( reader1.m_readOperations == 2 );
+        REQUIRE( reader1Done == true );
+
+        // Start my reader AGAIN (which will block waiting for data)
+        reader1.startReading( reader1Done );
+        Kit::System::sleep( 200 );  // Wait to ensure all reader loops have started
+        REQUIRE( reader1Done == false );
+        uut.close();  // This will unblock all clients
+
+        // Allow time for threads to stop
+        writer.terminate();
+        reader1.terminate();
+        REQUIRE( waitThreadInactive( w1 ) == true );
+        REQUIRE( waitThreadInactive( r1 ) == true );
+
+        Kit::System::Thread::destroy( *w1 );
+        Kit::System::Thread::destroy( *r1 );
+    }
+
+    SECTION( "blocked writer" )
+    {
+        char                 reader1Buf[100];
+        Reader               reader1( uut, reader1Buf, strlen( TEST_STRING2 ) );
+        Kit::System::Thread* r1 = Kit::System::Thread::create( reader1, "Reader1" );
+        REQUIRE( waitThreadActive( r1 ) == true );
+
+        Writer               writer( uut, TEST_STRING2 );
+        Kit::System::Thread* w1 = Kit::System::Thread::create( writer, "Writer" );
+        REQUIRE( waitThreadActive( w1 ) == true );
+
+        // Start my write
+        bool writerDone;
+        writer.startWriting( writerDone );
+        Kit::System::sleep( 200 );  // Wait to ensure write is done
+        REQUIRE( writerDone == true );
+        REQUIRE( writer.m_success == true );
+        REQUIRE( writer.m_writeOperations == 1 );
+
+        // Trigger the write again -->should block this time since the RingBuffer is only big enough for one write
+        writer.startWriting( writerDone );
+        Kit::System::sleep( 200 );  // Wait to ensure write is blocked
+        REQUIRE( writerDone == false );
+
+        // Trigger the read to unblock the writer
+        bool reader1Done;
+        reader1.startReading( reader1Done );
+        Kit::System::sleep( 500 );  // Wait to ensure read is done
+        REQUIRE( reader1Done == true );
+        REQUIRE( writerDone == true );
+        REQUIRE( writer.m_success == true );
+        REQUIRE( writer.m_writeOperations == 2 );
+        REQUIRE( reader1.m_bytesRead == strlen( TEST_STRING2 ) );
+        REQUIRE( reader1.m_readOperations == 1 );
+
+        // Trigger the write again -->should block again
+        writer.startWriting( writerDone );
+        Kit::System::sleep( 200 );  // Wait to ensure write is blocked
+        REQUIRE( writerDone == false );
+        uut.close();  // This will unblock all clients
+
+        // Allow time for threads to stop. 
+        writer.terminate();
+        reader1.terminate();
+        REQUIRE( waitThreadInactive( w1 ) == true );
+        REQUIRE( waitThreadInactive( r1 ) == true );
+
+        Kit::System::Thread::destroy( *w1 );
+        Kit::System::Thread::destroy( *r1 );
+    }
+
+    uut.close();
+    REQUIRE( Kit::System::ShutdownUnitTesting::getAndClearCounter() == 0u );
+}

--- a/src/Kit/Io/Serial/RPi/RP2xxx/Stdio/Input.cpp
+++ b/src/Kit/Io/Serial/RPi/RP2xxx/Stdio/Input.cpp
@@ -30,7 +30,7 @@ Input::Input() noexcept
 
 
 //////////////////////
-bool Input::read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept
+bool Input::read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept
 {
     // Ignore read requests of ZERO bytes
     bytesRead = 0;

--- a/src/Kit/Io/Serial/RPi/RP2xxx/Stdio/Input.h
+++ b/src/Kit/Io/Serial/RPi/RP2xxx/Stdio/Input.h
@@ -50,7 +50,7 @@ public:
     using Kit::Io::IInput::read;
 
     /// See Kit::Io::IInput
-    bool read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept override;
+    bool read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept override;
 
     /// See Kit::Io::IInput
     bool available() noexcept override;
@@ -63,7 +63,7 @@ public:
 
 protected:
     /// Cached byte when 'peeking' into the input stream
-    ByteCount_T m_nextByte;
+    Kit::Type::SSize_T m_nextByte;
 };
 
 

--- a/src/Kit/Io/Serial/RPi/RP2xxx/Stdio/Output.cpp
+++ b/src/Kit/Io/Serial/RPi/RP2xxx/Stdio/Output.cpp
@@ -23,7 +23,7 @@ namespace Stdio {
 
 
 //////////////////////
-bool Output::write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept
+bool Output::write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept
 {
     // Ignore write requests of ZERO bytes
     bytesWritten = 0;

--- a/src/Kit/Io/Serial/RPi/RP2xxx/Stdio/Output.h
+++ b/src/Kit/Io/Serial/RPi/RP2xxx/Stdio/Output.h
@@ -50,7 +50,7 @@ public:
     using Kit::Io::IOutput::write;
 
     /// See Kit::Io::IOutput
-    bool write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept override;
+    bool write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept override;
 
     /// See Kit::Io::IOutput
     void flush() noexcept override;

--- a/src/Kit/Io/Serial/RPi/RP2xxx/Uart/InputOutput.cpp
+++ b/src/Kit/Io/Serial/RPi/RP2xxx/Uart/InputOutput.cpp
@@ -266,7 +266,7 @@ bool InputOutput::available() noexcept
     return avail;
 }
 
-bool InputOutput::read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept
+bool InputOutput::read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept
 {
     bytesRead       = 0;
     uint8_t* dstPtr = static_cast<uint8_t*>( buffer );
@@ -326,7 +326,7 @@ bool InputOutput::read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRe
     return true;
 }
 
-bool InputOutput::write( const void* buffer, ByteCount_T numBytesToTx, ByteCount_T& bytesWritten ) noexcept
+bool InputOutput::write( const void* buffer, Kit::Type::SSize_T numBytesToTx, Kit::Type::SSize_T& bytesWritten ) noexcept
 {
     bytesWritten          = 0;
     const uint8_t* srcPtr = static_cast<const uint8_t*>( buffer );

--- a/src/Kit/Io/Serial/RPi/RP2xxx/Uart/InputOutput.h
+++ b/src/Kit/Io/Serial/RPi/RP2xxx/Uart/InputOutput.h
@@ -78,7 +78,7 @@ public:
     using Kit::Io::IInputOutput::read;
 
     /// See Kit::Io::IInput
-    bool read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept override;
+    bool read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept override;
 
     /// See Kit::Io::IInput
     bool available() noexcept override;
@@ -89,7 +89,7 @@ public:
     using Kit::Io::IInputOutput::write;
 
     /// See Kit::Io::IOutput
-    bool write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept override;
+    bool write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept override;
 
     /// See Kit::Io::IOutput
     void flush() noexcept override;

--- a/src/Kit/Io/Serial/RPi/RP2xxx/Uart/InputOutput.h
+++ b/src/Kit/Io/Serial/RPi/RP2xxx/Uart/InputOutput.h
@@ -38,7 +38,7 @@ namespace RP2xxx {
 namespace Uart {
 
 
-/** This concrete class implements a Input stream using Raspberry Pi UART
+/** This concrete class implements a Input/Output stream using Raspberry Pi UART
     interface/hardware. This implement provide a more robust stream interface
     than using 'stdio_uart' because it is interrupted driven and provides
     software TX/RX FIFOs

--- a/src/Kit/Io/Serial/ST/M32F4/InputOutput.cpp
+++ b/src/Kit/Io/Serial/ST/M32F4/InputOutput.cpp
@@ -38,7 +38,7 @@ void InputOutput::start( IRQn_Type           uartIrqNum,
 
 
 ////////////////////////////////////
-bool InputOutput::read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead )
+bool InputOutput::read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead )
 {
     return m_driver.read( buffer, numBytes, bytesRead );
 }
@@ -55,7 +55,7 @@ size_t InputOutput::getRxErrorsCounts( bool clearCount ) noexcept
 
 
 ////////////////////////////////////
-bool InputOutput::write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten )
+bool InputOutput::write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten )
 {
     bytesWritten = maxBytes;
     return m_driver.write( buffer, (size_t) maxBytes );

--- a/src/Kit/Io/Serial/ST/M32F4/InputOutput.h
+++ b/src/Kit/Io/Serial/ST/M32F4/InputOutput.h
@@ -65,7 +65,7 @@ public:
     using Kit::Io::IInputOutput::read;
 
     /// See Kit::Io::Input
-    bool read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept override;
+    bool read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept override;
 
     /// See Kit::Io::Input
     bool available() noexcept override;
@@ -78,7 +78,7 @@ public:
     using Kit::Io::IInputOutput::write;
 
     /// See Kit::Io::Output
-    bool write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept override;
+    bool write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept override;
 
     /// See Kit::Io::Output
     void flush() noexcept override;

--- a/src/Kit/Io/Serial/ST/M32F4/StreamDriver.cpp
+++ b/src/Kit/Io/Serial/ST/M32F4/StreamDriver.cpp
@@ -141,7 +141,7 @@ void StreamDriver::stop( void ) noexcept
 
 
 ////////////////////////
-bool StreamDriver::write( const void* data, ByteCount_T numBytesToTx ) noexcept
+bool StreamDriver::write( const void* data, Kit::Type::SSize_T numBytesToTx ) noexcept
 {
     // Fail the write if the driver has not been started
     if ( m_uartHdl == nullptr )
@@ -277,7 +277,7 @@ size_t StreamDriver::getRXErrorsCounts( bool clearCount ) noexcept
 }
 
 
-bool StreamDriver::read( void* data, ByteCount_T maxBytes, ByteCount_T& numBytesRx ) noexcept
+bool StreamDriver::read( void* data, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& numBytesRx ) noexcept
 {
     numBytesRx = 0;
 

--- a/src/Kit/Io/Serial/ST/M32F4/StreamDriver.h
+++ b/src/Kit/Io/Serial/ST/M32F4/StreamDriver.h
@@ -80,7 +80,7 @@ public:
         there is no guaranty/information-available with  respect to how many (if
         any) bytes where transmitted.
      */
-    bool write( const void* data, ByteCount_T numBytesToTx ) noexcept;
+    bool write( const void* data, Kit::Type::SSize_T numBytesToTx ) noexcept;
 
 
 public:
@@ -94,7 +94,7 @@ public:
               NOT put into the inbound buffer.  A free running counter is
               maintain of the number of framing errors encountered.
      */
-    bool read( void* data, ByteCount_T maxBytes, ByteCount_T& numBytesRx ) noexcept;
+    bool read( void* data, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& numBytesRx ) noexcept;
 
 
     /** This method returns true if at least one byte is available in the

--- a/src/Kit/Io/Serial/_0test/_hw_echo/test.cpp
+++ b/src/Kit/Io/Serial/_0test/_hw_echo/test.cpp
@@ -43,7 +43,7 @@ public:
     Kit::Io::IInputOutput&  m_fd;
     uint8_t                 m_rxMsg[RX_READ_BUFFER_SIZE];
     Kit::Text::FString<128> m_tmpBuf;
-    Kit::Io::ByteCount_T    m_numEchoBytes;
+    Kit::Type::SSize_T    m_numEchoBytes;
     uint8_t                 m_echoMemory[ECHO_BUFFER_SIZE + 1];
 
 public:
@@ -58,18 +58,18 @@ public:
         // Throw any trash bytes on startup
         while ( m_fd.available() )
         {
-            Kit::Io::ByteCount_T bytesRead;
+            Kit::Type::SSize_T bytesRead;
             m_fd.read( m_rxMsg, sizeof( m_rxMsg ), bytesRead );
         }
 
-        Kit::Io::ByteCount_T byteCount = 0;
+        Kit::Type::SSize_T byteCount = 0;
         uint8_t*             dstPtr    = m_echoMemory;
         m_numEchoBytes                 = 0;
 
         for ( ;; )
         {
 
-            Kit::Io::ByteCount_T bytesRead;
+            Kit::Type::SSize_T bytesRead;
             if ( m_fd.read( m_rxMsg, sizeof( m_rxMsg ), bytesRead ) )
             {
                 Bsp_toggle_debug1();
@@ -95,9 +95,9 @@ public:
         }
     }
 
-    void echoMemory( Kit::Io::ByteCount_T byteCount )
+    void echoMemory( Kit::Type::SSize_T byteCount )
     {
-        Kit::Io::ByteCount_T bytes = m_numEchoBytes;
+        Kit::Type::SSize_T bytes = m_numEchoBytes;
 
         uint8_t* srcData = m_echoMemory;
         while ( m_numEchoBytes )

--- a/src/Kit/Io/Serial/_0test/_hw_nothreads/test.cpp
+++ b/src/Kit/Io/Serial/_0test/_hw_nothreads/test.cpp
@@ -42,7 +42,7 @@ void test( Kit::Io::IInput& infd, Kit::Io::IOutput& outfd )
             Bsp_toggle_debug1();
         }
 
-        Kit::Io::ByteCount_T bytesRead  = 0;
+        Kit::Type::SSize_T bytesRead  = 0;
         if ( !infd.read( inbuffer, MAX_INPUT, bytesRead ) )
         {
             tmpString.format( "\n**** ERROR occurred while reading input stream (requested bytes=%d)\n", MAX_INPUT );

--- a/src/Kit/Io/Socket/InputOutput.h
+++ b/src/Kit/Io/Socket/InputOutput.h
@@ -47,7 +47,7 @@ public:
     using Kit::Io::IInput::read;
 
     /// See Kit::Io::IInput
-    bool read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept override;
+    bool read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept override;
 
     /// See Kit::Io::IInput
     bool available() noexcept override;
@@ -58,7 +58,7 @@ public:
     using Kit::Io::IOutput::write;
 
     /// See Kit::Io::IOutput
-    bool write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept override;
+    bool write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept override;
 
     /// See Kit::Io::IOutput
     void flush() noexcept override;

--- a/src/Kit/Io/Socket/Posix/Fdio.cpp
+++ b/src/Kit/Io/Socket/Posix/Fdio.cpp
@@ -35,7 +35,7 @@ void Fdio::close( int& fd ) noexcept
     }
 }
 
-bool Fdio::write( int fd, bool& eosFlag, const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept
+bool Fdio::write( int fd, bool& eosFlag, const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept
 {
     KIT_SYSTEM_ASSERT( buffer != nullptr );
 
@@ -53,7 +53,7 @@ bool Fdio::write( int fd, bool& eosFlag, const void* buffer, ByteCount_T maxByte
     }
 
     // perform the write
-    ByteCount_T result = send( fd, (char*)buffer, maxBytes, MSG_NOSIGNAL );
+    Kit::Type::SSize_T result = send( fd, (char*)buffer, maxBytes, MSG_NOSIGNAL );
     if ( result < 0 )
     {
         bytesWritten = 0;
@@ -81,7 +81,7 @@ bool Fdio::isOpened( int fd ) noexcept
     return fd != INVALID_FD;
 }
 
-bool Fdio::read( int fd, bool& eosFlag, void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept
+bool Fdio::read( int fd, bool& eosFlag, void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept
 {
     KIT_SYSTEM_ASSERT( buffer != nullptr );
 
@@ -99,7 +99,7 @@ bool Fdio::read( int fd, bool& eosFlag, void* buffer, ByteCount_T numBytes, Byte
     }
 
     // perform the read
-    ByteCount_T result = recv( fd, (char*)buffer, numBytes, 0 );
+    Kit::Type::SSize_T result = recv( fd, (char*)buffer, numBytes, 0 );
     if ( result < 0 )
     {
         bytesRead = 0;

--- a/src/Kit/Io/Socket/Posix/Fdio.h
+++ b/src/Kit/Io/Socket/Posix/Fdio.h
@@ -52,7 +52,7 @@ public:
 
         Returns true if successful; else false on error.
      */
-    static bool write( int fd, bool& eosFlag, const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept;
+    static bool write( int fd, bool& eosFlag, const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept;
 
     /// Flushes the file descriptor 'fd'
     static void flush( int fd ) noexcept;
@@ -71,7 +71,7 @@ public:
 
         Returns true if successful; else false on error.
      */
-    static bool read( int fd, bool& eosFlag, void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept;
+    static bool read( int fd, bool& eosFlag, void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept;
 
 
     /// Returns true if there is data available to be read from the file descriptor

--- a/src/Kit/Io/Socket/Posix/InputOutput.cpp
+++ b/src/Kit/Io/Socket/Posix/InputOutput.cpp
@@ -51,7 +51,7 @@ void InputOutput::activate( KitIoSocketHandle_T fd ) noexcept
 }
 
 ///////////////////
-bool InputOutput::read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept
+bool InputOutput::read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept
 {
     return Posix::Fdio::read( m_fd, m_eos, buffer, numBytes, bytesRead );
 }
@@ -63,7 +63,7 @@ bool InputOutput::available() noexcept
 
 
 //////////////////////
-bool InputOutput::write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept
+bool InputOutput::write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept
 {
     return Posix::Fdio::write( m_fd, m_eos, buffer, maxBytes, bytesWritten );
 }

--- a/src/Kit/Io/Socket/Win32/Fdio.h
+++ b/src/Kit/Io/Socket/Win32/Fdio.h
@@ -51,7 +51,7 @@ public:
 
         Returns true if successful; else false on error.
      */
-    static bool write( SOCKET fd, bool& eosFlag, const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept
+    static bool write( SOCKET fd, bool& eosFlag, const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept
     {
         KIT_SYSTEM_ASSERT( buffer != nullptr );
 
@@ -78,7 +78,7 @@ public:
         }
         
         // Success!
-        bytesWritten = static_cast<ByteCount_T>(result);
+        bytesWritten = static_cast<Kit::Type::SSize_T>(result);
         eosFlag      = false;
         return true;
     }
@@ -111,7 +111,7 @@ public:
         Returns true if successful; else false on error.
      */
 
-    static bool read( SOCKET fd, bool& eosFlag, void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept
+    static bool read( SOCKET fd, bool& eosFlag, void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept
     {
         KIT_SYSTEM_ASSERT( buffer != nullptr );
 
@@ -138,7 +138,7 @@ public:
         }
 
         // Success!
-        bytesRead = static_cast<ByteCount_T>(result);
+        bytesRead = static_cast<Kit::Type::SSize_T>(result);
         eosFlag   = false;
         return true;
     }

--- a/src/Kit/Io/Socket/Win32/InputOutput.cpp
+++ b/src/Kit/Io/Socket/Win32/InputOutput.cpp
@@ -51,7 +51,7 @@ void InputOutput::activate( KitIoSocketHandle_T fd ) noexcept
 }
 
 ///////////////////
-bool InputOutput::read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept
+bool InputOutput::read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept
 {
     return Win32::Fdio::read( m_fd, m_eos, buffer, numBytes, bytesRead );
 }
@@ -63,7 +63,7 @@ bool InputOutput::available() noexcept
 
 
 //////////////////////
-bool InputOutput::write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept
+bool InputOutput::write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept
 {
     return Win32::Fdio::write( m_fd, m_eos, buffer, maxBytes, bytesWritten );
 }

--- a/src/Kit/Io/Stdio/InputDelegate.h
+++ b/src/Kit/Io/Stdio/InputDelegate.h
@@ -40,7 +40,7 @@ public:
     using Kit::Io::IInput::read;
 
     /// See Kit::Io::IInput
-    bool read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept override;
+    bool read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept override;
 
     /// See Kit::Io::IInput
     bool available() noexcept override;

--- a/src/Kit/Io/Stdio/OutputDelegate.h
+++ b/src/Kit/Io/Stdio/OutputDelegate.h
@@ -43,7 +43,7 @@ public:
     using Kit::Io::IOutput::write;
 
     /// See Kit::Io::IOutput
-    bool write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept override;
+    bool write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept override;
 
     /// See Kit::Io::Output
     void flush() noexcept override;

--- a/src/Kit/Io/Stdio/Posix/Fdio.cpp
+++ b/src/Kit/Io/Stdio/Posix/Fdio.cpp
@@ -20,7 +20,7 @@ namespace Io {
 namespace Stdio {
 namespace Posix {
 
-bool Fdio::write( int fd, bool& eosFlag, const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept
+bool Fdio::write( int fd, bool& eosFlag, const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept
 {
     KIT_SYSTEM_ASSERT( buffer != nullptr );
 
@@ -66,7 +66,7 @@ void Fdio::close( int& fd ) noexcept
     }
 }
 
-bool Fdio::read( int fd, bool& eosFlag, void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept
+bool Fdio::read( int fd, bool& eosFlag, void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept
 {
     KIT_SYSTEM_ASSERT( buffer != nullptr );
 

--- a/src/Kit/Io/Stdio/Posix/Fdio.h
+++ b/src/Kit/Io/Stdio/Posix/Fdio.h
@@ -43,7 +43,7 @@ public:
 
         Returns true if successful; else false on error.
      */
-    static bool write( int fd, bool& eosFlag, const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept;
+    static bool write( int fd, bool& eosFlag, const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept;
 
     /// Flushes the file descriptor 'fd'
     static void flush( int fd ) noexcept;
@@ -68,7 +68,7 @@ public:
 
         Returns true if successful; else false on error.
      */
-    static bool read( int fd, bool& eosFlag, void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept;
+    static bool read( int fd, bool& eosFlag, void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept;
 
     /** Returns true if there is data available to be read from the file descriptor
      */

--- a/src/Kit/Io/Stdio/Posix/InputDelegate.cpp
+++ b/src/Kit/Io/Stdio/Posix/InputDelegate.cpp
@@ -25,7 +25,7 @@ InputDelegate::InputDelegate( KitIoStdioHandle_T fd )
 }
 
 //////////////////////
-bool InputDelegate::read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept
+bool InputDelegate::read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept
 {
     return Posix::Fdio::read( m_inFd, m_inEos, buffer, numBytes, bytesRead );
 }

--- a/src/Kit/Io/Stdio/Posix/OutputDelegate.cpp
+++ b/src/Kit/Io/Stdio/Posix/OutputDelegate.cpp
@@ -25,7 +25,7 @@ OutputDelegate::OutputDelegate( KitIoStdioHandle_T fd ) noexcept
 }
 
 //////////////////////
-bool OutputDelegate::write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept
+bool OutputDelegate::write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept
 {
     return Posix::Fdio::write( m_outFd, m_outEos, buffer, maxBytes, bytesWritten );
 }

--- a/src/Kit/Io/Stdio/Win32/Fdio.cpp
+++ b/src/Kit/Io/Stdio/Win32/Fdio.cpp
@@ -34,7 +34,7 @@ namespace Stdio {
 namespace Win32 {
 
 
-bool Fdio::write( HANDLE fd, bool& eosFlag, const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept
+bool Fdio::write( HANDLE fd, bool& eosFlag, const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept
 {
     KIT_SYSTEM_ASSERT( buffer != nullptr );
 
@@ -54,7 +54,7 @@ bool Fdio::write( HANDLE fd, bool& eosFlag, const void* buffer, ByteCount_T maxB
     // perform the write
     unsigned long work;
     BOOL          result = WriteFile( fd, buffer, maxBytes, &work, 0 );
-    bytesWritten         = static_cast<ByteCount_T>( work );
+    bytesWritten         = static_cast<Kit::Type::SSize_T>( work );
     DWORD lastError      = GetLastError();
     eosFlag              = ( result != 0 || bytesWritten > 0 )                                                    ? false
                            : lastError == ERROR_HANDLE_EOF || lastError == ERROR_BROKEN_PIPE || bytesWritten == 0 ? true
@@ -86,7 +86,7 @@ void Fdio::close( HANDLE& fd ) noexcept
 }
 
 
-bool Fdio::read( HANDLE fd, bool& eosFlag, void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept
+bool Fdio::read( HANDLE fd, bool& eosFlag, void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept
 {
     KIT_SYSTEM_ASSERT( buffer != nullptr );
 
@@ -106,7 +106,7 @@ bool Fdio::read( HANDLE fd, bool& eosFlag, void* buffer, ByteCount_T numBytes, B
     // perform the read
     unsigned long work;
     BOOL          result = ReadFile( fd, buffer, numBytes, &work, 0 );
-    bytesRead            = static_cast<ByteCount_T>( work );
+    bytesRead            = static_cast<Kit::Type::SSize_T>( work );
     DWORD lastError      = GetLastError();
     eosFlag              = ( result != 0 && bytesRead > 0 )                                                    ? false
                            : lastError == ERROR_HANDLE_EOF || lastError == ERROR_BROKEN_PIPE || bytesRead == 0 ? true

--- a/src/Kit/Io/Stdio/Win32/Fdio.h
+++ b/src/Kit/Io/Stdio/Win32/Fdio.h
@@ -37,7 +37,7 @@ public:
 
         Returns true if successful; else false on error. Note: .
      */
-    static bool write( HANDLE fd, bool& eosFlag, const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept;
+    static bool write( HANDLE fd, bool& eosFlag, const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept;
 
     /// Flushes the file descriptor 'fd'
     static void flush( HANDLE fd ) noexcept;
@@ -62,7 +62,7 @@ public:
 
         Returns true if successful; else false on error.
      */
-    static bool read( HANDLE fd, bool& eosFlag, void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept;
+    static bool read( HANDLE fd, bool& eosFlag, void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept;
 
     /** Returns true if there is data available to be read from STDIN
 

--- a/src/Kit/Io/Stdio/Win32/InputDelegate.cpp
+++ b/src/Kit/Io/Stdio/Win32/InputDelegate.cpp
@@ -25,7 +25,7 @@ InputDelegate::InputDelegate( KitIoStdioHandle_T fd )
 }
 
 //////////////////////
-bool InputDelegate::read( void* buffer, ByteCount_T numBytes, ByteCount_T& bytesRead ) noexcept
+bool InputDelegate::read( void* buffer, Kit::Type::SSize_T numBytes, Kit::Type::SSize_T& bytesRead ) noexcept
 {
     return Win32::Fdio::read( m_inFd, m_inEos, buffer, numBytes, bytesRead );
 }

--- a/src/Kit/Io/Stdio/Win32/OutputDelegate.cpp
+++ b/src/Kit/Io/Stdio/Win32/OutputDelegate.cpp
@@ -25,7 +25,7 @@ OutputDelegate::OutputDelegate( KitIoStdioHandle_T fd ) noexcept
 }
 
 //////////////////////
-bool OutputDelegate::write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept
+bool OutputDelegate::write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept
 {
     return Win32::Fdio::write( m_outFd, m_outEos, buffer, maxBytes, bytesWritten );
 }

--- a/src/Kit/Io/TeeOutput.cpp
+++ b/src/Kit/Io/TeeOutput.cpp
@@ -114,7 +114,7 @@ IOutput* TeeOutput::next( IOutput** streamList, IOutput& currentStream ) const n
 }
 
 ///////////////////////////////
-bool TeeOutput::write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept
+bool TeeOutput::write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept
 {
     bool     rc     = true;
     IOutput* stream = first( m_streams );
@@ -140,7 +140,7 @@ bool TeeOutput::write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& by
         }
 
         // IOutput to stream -->and trap any error
-        ByteCount_T tempWritten;
+        Kit::Type::SSize_T tempWritten;
         if ( !stream->write( buffer, maxBytes, tempWritten ) )
         {
             // move the stream with an error to the failed list

--- a/src/Kit/Io/TeeOutput.h
+++ b/src/Kit/Io/TeeOutput.h
@@ -82,7 +82,7 @@ public:
     using Kit::Io::IOutput::write;
 
     /// See Kit::Io::IOutput
-    bool write( const void* buffer, ByteCount_T maxBytes, ByteCount_T& bytesWritten ) noexcept override;
+    bool write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept override;
 
     /// See Kit::Io::IOutput
     void flush() noexcept override;

--- a/src/Kit/Io/Types.h
+++ b/src/Kit/Io/Types.h
@@ -12,6 +12,7 @@
 
 #include "kit_config.h"
 #include "kit_map.h"
+#include "Kit/Type/SSize.h"
 #include <stdint.h>
 
 
@@ -53,25 +54,6 @@ static constexpr const char* const nativeNewline = KIT_IO_NEW_LINE_NATIVE;
  */
 #define KitIoSocketHandle_T KitIoSocketHandle_T_MAP
 
-/*----------------------------------------------------------------------------*/
-/** Signed data type for arguments, variables, etc. with respect to how many
-    bytes can be read/written from/to streams, files, etc.  The default is
-    for a signed 32 bit integer.  A platform can override the default to make
-    larger or smaller as needed.
-
-    Note: This is my work-around for the fact that C++ does not have a
-          standard 'ssize_t' type. ssize_t is defined in POSIX and is used when
-          read/write operations using file descriptors.
- */
-#ifndef OPTION_KIT_IO_LENGTH_TYPE
-using ByteCount_T = int32_t;
-
-/// Alias for Offset type (used for seek operations)
-using Offset_T    = int32_t;
-#else
-using ByteCount_T = OPTION_KIT_IO_LENGTH_TYPE;
-using Offset_T    = OPTION_KIT_IO_LENGTH_TYPE;
-#endif
 
 }  // end namespaces
 }

--- a/src/Kit/Io/_0test/null.cpp
+++ b/src/Kit/Io/_0test/null.cpp
@@ -46,7 +46,7 @@ public:
         return fd.write( "Hello" );
     }
 };
-}; // end namespace
+} // end namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 TEST_CASE( "null" )

--- a/src/Kit/Json/_0test/arduinohelpers.cpp
+++ b/src/Kit/Json/_0test/arduinohelpers.cpp
@@ -9,6 +9,7 @@
 #include "Kit/System/Trace.h"
 #include "Kit/Io/IOutput.h"
 #include "Kit/Text/FString.h"
+#include "Kit/Type/SSize.h"
 #include <limits>
 
 
@@ -17,7 +18,7 @@ namespace
 class OutputSink : public Kit::Io::IOutput
 {
 public:
-    bool write( const void* buffer, Kit::Io::ByteCount_T maxBytes, Kit::Io::ByteCount_T& bytesWritten ) noexcept override
+    bool write( const void* buffer, Kit::Type::SSize_T maxBytes, Kit::Type::SSize_T& bytesWritten ) noexcept override
     {
         bytesWritten = maxBytes;
         if ( buffer == nullptr || maxBytes <= 0 )
@@ -26,7 +27,7 @@ public:
         }
 
         const char* src = static_cast<const char*>( buffer );
-        for ( Kit::Io::ByteCount_T i = 0; i < maxBytes; ++i )
+        for ( Kit::Type::SSize_T i = 0; i < maxBytes; ++i )
         {
             m_contents += src[i];
         }

--- a/src/Kit/Persistence/Record/Media/FileAdapter.cpp
+++ b/src/Kit/Persistence/Record/Media/FileAdapter.cpp
@@ -50,7 +50,7 @@ bool FileAdapter::write( Size_T offset, const void* srcData, Size_T srcLen ) noe
     bool result = fd.setAbsolutePos( offset );
     if ( result )
     {
-        result = fd.write( srcData, static_cast<Io::ByteCount_T>( srcLen ) );
+        result = fd.write( srcData, static_cast<Io::Kit::Type::SSize_T>( srcLen ) );
     }
 
     fd.close();
@@ -78,7 +78,7 @@ Size_T FileAdapter::read( Size_T offset, void* dstBuffer, Size_T bytesToRead ) n
         return KIT_PERSISTENCE_SIZE_MAX;
     }
 
-    result = fd.read( dstBuffer, static_cast<Io::ByteCount_T>( bytesToRead ) );
+    result = fd.read( dstBuffer, static_cast<Io::Kit::Type::SSize_T>( bytesToRead ) );
 
     fd.close();
     return result ? bytesToRead : KIT_PERSISTENCE_SIZE_MAX;

--- a/src/Kit/Persistence/Record/Media/FileAdapter.cpp
+++ b/src/Kit/Persistence/Record/Media/FileAdapter.cpp
@@ -50,7 +50,7 @@ bool FileAdapter::write( Size_T offset, const void* srcData, Size_T srcLen ) noe
     bool result = fd.setAbsolutePos( offset );
     if ( result )
     {
-        result = fd.write( srcData, static_cast<Io::Kit::Type::SSize_T>( srcLen ) );
+        result = fd.write( srcData, static_cast<Kit::Type::SSize_T>( srcLen ) );
     }
 
     fd.close();
@@ -78,7 +78,7 @@ Size_T FileAdapter::read( Size_T offset, void* dstBuffer, Size_T bytesToRead ) n
         return KIT_PERSISTENCE_SIZE_MAX;
     }
 
-    result = fd.read( dstBuffer, static_cast<Io::Kit::Type::SSize_T>( bytesToRead ) );
+    result = fd.read( dstBuffer, static_cast<Kit::Type::SSize_T>( bytesToRead ) );
 
     fd.close();
     return result ? bytesToRead : KIT_PERSISTENCE_SIZE_MAX;

--- a/src/Kit/Text/Tokenizer/TextBlock.cpp
+++ b/src/Kit/Text/Tokenizer/TextBlock.cpp
@@ -10,6 +10,7 @@
 
 #include "TextBlock.h"
 #include "Kit/Text/Strip.h"
+#include "Kit/System/Assert.h"
 #include <string.h>
 #include <ctype.h>
 
@@ -33,12 +34,20 @@ TextBlock::TextBlock( char* string,
     , m_validTokens( true )
     , m_terminatorFound( false )
 {
+    KIT_SYSTEM_ASSERT( delimiter != terminator );
+    KIT_SYSTEM_ASSERT( delimiter != quote );
+    KIT_SYSTEM_ASSERT( delimiter != escape );
+    KIT_SYSTEM_ASSERT( terminator != quote );
+    KIT_SYSTEM_ASSERT( terminator != escape );
+    KIT_SYSTEM_ASSERT( quote != escape );
+    
     // Flag an error if 'string' is null
     if ( string == nullptr )
     {
         m_validTokens = false;
         return;
     }
+
     // Do nothing (aka zero parameter count) if the string is empty AFTER removing whitespace
     if ( *m_ptr == '\0' )
     {
@@ -110,6 +119,7 @@ TextBlock::TextBlock( char* string,
             removeCharacter_( m_ptr );
             m_validTokens = false;
             bool escaping = false;
+            bool quotedTokenHasContent = false;
             if ( firstNonSpacePtr == nullptr )
             {
                 firstNonSpacePtr = m_ptr;
@@ -122,6 +132,7 @@ TextBlock::TextBlock( char* string,
                 if ( escaping )
                 {
                     escaping = false;
+                    quotedTokenHasContent = true;
                     m_ptr++;
                 }
 
@@ -130,7 +141,7 @@ TextBlock::TextBlock( char* string,
                 {
                     // Remove the ending quote character
                     removeCharacter_( m_ptr );
-                    lastNonSpacePtr = m_ptr - 1;
+                    lastNonSpacePtr = quotedTokenHasContent ? ( m_ptr - 1 ) : nullptr;
                     m_validTokens   = true;
                     break;
                 }
@@ -145,6 +156,7 @@ TextBlock::TextBlock( char* string,
                 // Normal character
                 else
                 {
+                    quotedTokenHasContent = true;
                     m_ptr++;
                 }
             }

--- a/src/Kit/Text/Tokenizer/TextBlock.h
+++ b/src/Kit/Text/Tokenizer/TextBlock.h
@@ -52,8 +52,11 @@ namespace Tokenizer {
     string. To enter a literal QUOTE character within a text string, precede the
     QUOTE character with the ESC character (e.g., \").  To enter a literal ESC
     character within a text string, precede the character with ESC character
-    (e.g., \\). IMPORTANT NOTE: The QUOTE and ESC characters are REMOVED from
+    (e.g., \\). IMPORTANT: The QUOTE and ESC characters are REMOVED from
     the string when it is tokenized!
+
+    NOTE: A TEXT STRING can be empty (e.g. \"\").  When/if encountered, an 
+          empty TEXT STRING is treated as a parameter with zero string length.
 
 
 </pre>*/
@@ -61,7 +64,7 @@ class TextBlock
 {
 public:
     /** Constructor.  Requires a pointer to the 'raw' string to be tokenized.
-        Note: ALL OF THE PARSING OCCURS IN THIS METHOD.
+        NOTE: ALL OF THE PARSING OCCURS IN THIS METHOD.
      */
     TextBlock( char* string,
                char  delimiter  = ',',

--- a/src/Kit/Text/Tokenizer/_0test/textblock.cpp
+++ b/src/Kit/Text/Tokenizer/_0test/textblock.cpp
@@ -77,6 +77,43 @@ TEST_CASE( "textblock" )
         REQUIRE( parser.getParameter( 0 ) == 0 );
     }
 
+    SECTION( "Defaults#2a..." )
+    {
+        int                    dummy;
+        Kit::Text::FString<64> token;
+        Kit::Text::FString<64> rawString = "\"\"";
+        KIT_SYSTEM_TRACE_MSG( SECT_, "original=[%s]", rawString.getString() );
+        TextBlock parser( rawString.getBuffer( dummy ) );
+
+        REQUIRE( parser.isValidTokens() );
+        REQUIRE( parser.numParameters() == 1 );
+        REQUIRE( parser.isTerminated() == false );
+        REQUIRE( parser.getParameter( 1 ) == 0 );
+        token = parser.getParameter( 0 );
+        KIT_SYSTEM_TRACE_MSG( SECT_, " token=[%s]", token.getString() );
+        REQUIRE( token.isEmpty() );
+    }
+
+    SECTION( "Defaults#2b..." )
+    {
+        int                    dummy;
+        Kit::Text::FString<64> token;
+        Kit::Text::FString<64> rawString = "a,\"\"";
+        KIT_SYSTEM_TRACE_MSG( SECT_, "original=[%s]", rawString.getString() );
+        TextBlock parser( rawString.getBuffer( dummy ) );
+
+        REQUIRE( parser.isValidTokens() );
+        REQUIRE( parser.numParameters() == 2 );
+        REQUIRE( parser.isTerminated() == false );
+        REQUIRE( parser.getParameter( 2 ) == 0 );
+        token = parser.getParameter( 0 );
+        KIT_SYSTEM_TRACE_MSG( SECT_, " token=[%s]", token.getString() );
+        REQUIRE( token == "a" );
+        token = parser.getParameter( 1 );
+        KIT_SYSTEM_TRACE_MSG( SECT_, " token=[%s]", token.getString() );
+        REQUIRE( token.isEmpty() );
+    }
+
     SECTION( "Defaults#3..." )
     {
         int                    dummy;

--- a/src/Kit/Type/SSize.h
+++ b/src/Kit/Type/SSize.h
@@ -1,0 +1,41 @@
+#ifndef KIT_TYPES_SSIZET_H_
+#define KIT_TYPES_SSIZET_H_
+/*------------------------------------------------------------------------------
+ * Copyright Integer Fox Authors
+ *
+ * Distributed under the BSD 3 Clause License. See the license agreement at:
+ * https://github.com/Integerfox/kit.core/blob/main/LICENSE
+ *
+ * Redistributions of the source code must retain the above copyright notice.
+ *----------------------------------------------------------------------------*/
+/** @file */
+
+#include "kit_config.h"
+#include <stdint.h>
+
+
+///
+namespace Kit {
+///
+namespace Type {
+
+/*----------------------------------------------------------------------------*/
+/** This is my work-around for the fact that C++ does not have a standard
+    'ssize_t' type. ssize_t is defined in POSIX and one primary usage is with
+    read/write operations using file descriptors.Signed data type for arguments,
+    variables, etc. with respect to how many bytes can be read/written from/to
+    streams, files, etc.  The default is for a signed 32 bit integer.  A
+    platform can override the default to make larger or smaller as needed.
+
+
+ */
+#ifndef OPTION_KIT_TYPE_SSIZET_LENGTH_TYPE
+using SSize_T = int32_t;
+
+#else
+using SSize_T = OPTION_KIT_TYPE_SSIZET_LENGTH_TYPE;
+#endif
+
+}  // end namespaces
+}
+#endif  // end header latch

--- a/src/Kit/_support/testing/helpers.h
+++ b/src/Kit/_support/testing/helpers.h
@@ -14,6 +14,8 @@
  */
 
 #include "Kit/System/Api.h"
+#include "Kit/System/Thread.h"
+#include "Kit/System/ElapsedTime.h"
 #include "Kit/System/Mutex.h"
 #include "Kit/System/Semaphore.h"
 #include "Kit/System/IEventFlag.h"
@@ -164,6 +166,28 @@ bool minWaitOnModelPointSeqNumChange( MPTYPE& src, uint16_t currentSeqNum, unsig
         *newSeqNum = seqNum;
     }
     return false;
+};
+
+/// This method busy waits till the specified thread is active/running. Returns false if TIMED-OUT  
+inline bool waitThreadActive( Kit::System::Thread* threadPtr, uint32_t maxWaitMs = 1000, uint32_t waitDelayMs = 10 )
+{
+    uint32_t startTime = Kit::System::ElapsedTime::milliseconds();
+    while ( !Kit::System::Thread::isActiveThread( threadPtr ) && !Kit::System::ElapsedTime::expiredMilliseconds( startTime, maxWaitMs ) )
+    {
+        Kit::System::sleep( waitDelayMs );
+    }
+    return Kit::System::Thread::isActiveThread( threadPtr );
+};
+
+/// This method busy waits till the specified thread is NOT active/running. Returns false if TIMED-OUT 
+inline bool waitThreadInactive( Kit::System::Thread* threadPtr, uint32_t maxWaitMs = 1000, uint32_t waitDelayMs = 10 )
+{
+    uint32_t startTime = Kit::System::ElapsedTime::milliseconds();
+    while ( Kit::System::Thread::isActiveThread( threadPtr ) && !Kit::System::ElapsedTime::expiredMilliseconds( startTime, maxWaitMs ) )
+    {
+        Kit::System::sleep( waitDelayMs );
+    }
+    return !Kit::System::Thread::isActiveThread( threadPtr );
 };
 
 /** This class is a EventQueue Server that signals the provided semaphore when

--- a/top/compilers/01-vcvars32-vc17.bat
+++ b/top/compilers/01-vcvars32-vc17.bat
@@ -3,7 +3,7 @@
 
 :: Get the version from the compiler itself
 set _CC_VER=
-for /f "tokens=7 delims= " %%a in ('cl 2^>^&1 ^| findstr /R /C:"for x86$"') do set _CC_VER=%%a
+for /f "tokens=7 delims= " %%a in ('cl 2^>^&1 ^| findstr /R /C:"Version 19\..* for x86$"') do set _CC_VER=%%a
 
 :: Set the name for the toolchain. It includes the compiler version
 set NAME=Visual Studio VC17 x86
@@ -24,11 +24,31 @@ if "%1"=="isConfigured" (
 )
 
 :: Set/Configure the toolchain
-if "/%_CC_VER%"=="/" (
-    :: Run Visual Studio VC17 (32bit) environment setup
-    call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars32.bat"
-)
+call :resolve_vcvars
+if ERRORLEVEL 1 exit /b 1
+call "%_VCVARS_BAT%"
+
 :: Display the version info
 for /f "tokens=7 delims= " %%a in ('cl 2^>^&1 ^| findstr /R /C:"Version"') do set _CC_VER=%%a
 echo:Environment set: Visual Studio VC17 x86. Ver:%_CC_VER%
+exit /b 0
+
+:resolve_vcvars
+set _VCVARS_BAT=
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
+    for /f "usebackq delims=" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find VC\Auxiliary\Build\vcvars32.bat 2^>nul`) do set _VCVARS_BAT=%%i
+)
+
+if not "%_VCVARS_BAT%"=="" goto :eof
+
+@REM if exist "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars32.bat" set _VCVARS_BAT=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars32.bat
+@REM if exist "C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvars32.bat" set _VCVARS_BAT=C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvars32.bat
+@REM if exist "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat" set _VCVARS_BAT=C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat
+@REM if exist "C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars32.bat" set _VCVARS_BAT=C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars32.bat
+
+if "%_VCVARS_BAT%"=="" (
+    echo:ERROR: Unable to locate vcvars32.bat for Visual Studio 2022.
+    exit /b 1
+)
+goto :eof
 

--- a/top/compilers/02-vcvars64-vc17.bat
+++ b/top/compilers/02-vcvars64-vc17.bat
@@ -3,7 +3,7 @@
 
 :: Get the version from the compiler itself
 set _CC_VER=
-for /f "tokens=7 delims= " %%a in ('cl 2^>^&1 ^| findstr /R /C:"for x64$"') do set _CC_VER=%%a
+for /f "tokens=7 delims= " %%a in ('cl 2^>^&1 ^| findstr /R /C:"Version 19\..* for x64$"') do set _CC_VER=%%a
 
 :: Set the name for the toolchain. It includes the compiler version
 set NAME=Visual Studio VC17 x64
@@ -24,13 +24,26 @@ if "%1"=="isConfigured" (
 )
 
 :: Set/Configure the toolchain
-if "/%_CC_VER%"=="/" (
-    :: Run Visual Studio VC17 (64bit) environment setup
-    call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
-)
+call :resolve_vcvars
+if ERRORLEVEL 1 exit /b 1
+call "%_VCVARS_BAT%"
+
 :: Display the version info
 for /f "tokens=7 delims= " %%a in ('cl 2^>^&1 ^| findstr /R /C:"Version"') do set _CC_VER=%%a
 echo:Environment set: Visual Studio VC17 x64. Ver:%_CC_VER%
+exit /b 0
+
+:resolve_vcvars
+set _VCVARS_BAT=
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
+    for /f "usebackq delims=" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find VC\Auxiliary\Build\vcvars64.bat 2^>nul`) do set _VCVARS_BAT=%%i
+)
+
+if not "%_VCVARS_BAT%"=="" goto :eof
+echo:ERROR: Unable to locate vcvars64.bat for Visual Studio 2022.
+exit /b 1
+
+goto :eof
 
 
 


### PR DESCRIPTION
- Created new namespace for the "framer" stuffs.
- Only implemented the minimum framing needed by the upcoming TShell port
- Refactored the CPL implementation to use composition (instead of inheritance) with respect to the input/output permutations
- Refactored the Kit::Io ByteCount_T types to be non-namespace specific to Kit::Type::SSize_T - since its use not specific to just IO semantics.
- Added a RAM FIFO based Kit::Io stream (helpful for unit testing stream source/destinations)
- Added some more 'unit test' helper functions